### PR TITLE
fix(cache): prevent 2013 matches from contaminating current tournaments (#29)

### DIFF
--- a/components/MatchList/MatchListV2.tsx
+++ b/components/MatchList/MatchListV2.tsx
@@ -376,9 +376,7 @@ export const MatchListV2: React.FC<MatchListV2Props> = ({
     });
 
     if (filtered.length !== propMatches.length) {
-      console.log(
-        `[MatchListV2 web] Year filter (${targetYear}): kept ${filtered.length}/${propMatches.length} matches`
-      );
+      console.warn(`[MatchListV2] Year filter removed ${propMatches.length - filtered.length} wrong-year matches (targetYear=${targetYear})`);
     }
 
     return filtered;

--- a/screens/TournamentDetailScreen.tsx
+++ b/screens/TournamentDetailScreen.tsx
@@ -1213,12 +1213,14 @@ const TournamentDetailScreenContent: React.FC = () => {
       ? new Date(tournament.dates.startDate).getFullYear()
       : new Date().getFullYear();
 
+    console.log(`[loadMatches] visNo=${tournament.visNo} year=${tournamentYear}`);
+
     try {
       // STEP 1: Check cache first for matches (with year parameter)
       const cachedMatches = await TournamentMatchCache.getCachedMatches(tournament.visNo, tournamentYear);
 
       if (cachedMatches) {
-        console.log(`📦 ✅ Using cached matches for tournament ${tournament.visNo} year ${tournamentYear}`);
+        console.log(`[loadMatches] Cache HIT: ${cachedMatches.length} matches`);
         setMatches(cachedMatches);
         setMatchesLoading(false);
         setLoadMatchesInProgress(false);
@@ -1299,6 +1301,8 @@ const TournamentDetailScreenContent: React.FC = () => {
                   gender: genderMatch ? genderMatch[1] : null
                 };
               });
+
+              console.log(`[loadMatches] GetEvent(${tournament.visNo}) → ${tournaments.length} BeachTournaments`);
 
               // Store tournament list for subsequent API calls
               const validTournaments = tournaments.filter(t => t.no && t.gender);
@@ -1620,6 +1624,18 @@ const TournamentDetailScreenContent: React.FC = () => {
 
       // Parse the response asynchronously to avoid blocking UI
       if (allMatches.length > 0) {
+        // FIX #29: Filter out wrong-year matches before displaying or caching
+        // The VIS API may return matches from other years if tournament codes are reused across seasons
+        const beforeFilter = allMatches.length;
+        allMatches = allMatches.filter(m => {
+          const d = (m as any).scheduledDateTime || (m as any).LocalDate;
+          if (!d) return true; // Keep matches without dates (TBD)
+          return new Date(d).getFullYear() === tournamentYear;
+        });
+        if (allMatches.length !== beforeFilter) {
+          console.warn(`⚠️ [FIX-29] Filtered ${beforeFilter - allMatches.length} wrong-year matches from API response (kept ${allMatches.length}/${beforeFilter} for year ${tournamentYear})`);
+        }
+
         setTimeout(async () => {
           try {
             // Sort matches by date and time in DESCENDING order (newest/latest first)
@@ -1791,8 +1807,11 @@ const TournamentDetailScreenContent: React.FC = () => {
       setMatchesLoading(true);
       setLoadMatchesInProgress(false); // Reset guard so the new tournament can load
 
-      // Track recently viewed tournament for cache warming
-      TournamentCacheWarmingService.trackRecentlyViewed(tournament.visNo);
+      // Track recently viewed tournament for cache warming (with year for date-scoped warming)
+      const trackYear = tournament.dates?.startDate
+        ? new Date(tournament.dates.startDate).getFullYear()
+        : new Date().getFullYear();
+      TournamentCacheWarmingService.trackRecentlyViewed(tournament.visNo, trackYear);
 
       // Load tournament display data (country, location info for TournamentCard)
       loadTournamentDisplayData();

--- a/services/api/VisApiClient.ts
+++ b/services/api/VisApiClient.ts
@@ -931,7 +931,8 @@ export class VisApiClient implements IVisApiClient {
         method: 'POST',
         headers,
         body: formData,
-        signal: controller.signal
+        signal: controller.signal,
+        cache: 'no-store', // FIX #29: Prevent browser HTTP cache from serving stale VIS API responses
       });
 
       if (!response.ok) {

--- a/services/cache/TournamentCacheWarmingService.ts
+++ b/services/cache/TournamentCacheWarmingService.ts
@@ -18,6 +18,7 @@ interface RecentTournament {
   tournamentNo: string;
   lastViewed: string;
   status?: string;
+  year?: number; // Tournament year for date-scoped API calls
 }
 
 export class TournamentCacheWarmingService {
@@ -88,7 +89,7 @@ export class TournamentCacheWarmingService {
       // Warm in parallel but rate-limited
       const promises = tournamentsToWarm
         .slice(0, this.MAX_CONCURRENT_WARMING)
-        .map(tournament => this.warmSingleTournament(tournament.tournamentNo));
+        .map(tournament => this.warmSingleTournament(tournament.tournamentNo, tournament.year));
 
       await Promise.all(promises);
 
@@ -100,35 +101,53 @@ export class TournamentCacheWarmingService {
   /**
    * Warm cache for a single tournament
    * @param tournamentNo - Tournament number to warm
+   * @param year - Tournament year for date-scoped API calls
    */
-  private static async warmSingleTournament(tournamentNo: string): Promise<void> {
+  private static async warmSingleTournament(tournamentNo: string, year?: number): Promise<void> {
     if (this.warmingInProgress.has(tournamentNo)) {
       return; // Already warming this tournament
     }
 
     this.warmingInProgress.add(tournamentNo);
 
+    // Use provided year or default to current year
+    const targetYear = year || new Date().getFullYear();
+
     try {
-      // Check if already cached and fresh
-      const hasFreshCache = await TournamentMatchCache.hasFreshCache(tournamentNo);
+      // Check if already cached and fresh (with year)
+      const hasFreshCache = await TournamentMatchCache.hasFreshCache(tournamentNo, targetYear);
       if (hasFreshCache) {
         return;
       }
 
-      console.log(`🔥 Warming tournament ${tournamentNo}`);
+      console.log(`🔥 Warming tournament ${tournamentNo} year ${targetYear}`);
 
-      // Fetch and cache tournament data
-      const matches = await this.fetchTournamentMatches(tournamentNo);
+      // Fetch with year filtering to avoid cross-year contamination
+      const matches = await this.fetchTournamentMatches(tournamentNo, targetYear);
 
       if (matches && matches.length > 0) {
-        // Determine tournament status from matches
-        const status = this.determineTournamentStatus(matches);
+        // FIX #29: Filter matches to only include the target year
+        // The VIS API may return matches from other years if tournamentNo is reused across seasons
+        const filteredMatches = matches.filter(m => {
+          const d = (m as any).scheduledDateTime;
+          if (!d) return true; // Keep matches without dates (TBD)
+          return new Date(d).getFullYear() === targetYear;
+        });
 
-        // Extract year from matches to fix João Pessoa bug
-        const year = new Date(matches[0].scheduledDateTime).getFullYear();
+        if (filteredMatches.length === 0) {
+          console.warn(`⚠️ Warming ${tournamentNo}: all ${matches.length} matches filtered out (none from ${targetYear})`);
+          return;
+        }
 
-        await TournamentMatchCache.cacheMatches(tournamentNo, matches, status, year);
-        console.log(`✅ Successfully warmed cache for tournament ${tournamentNo} year ${year} (${matches.length} matches)`);
+        if (filteredMatches.length !== matches.length) {
+          console.warn(`⚠️ Warming ${tournamentNo}: filtered ${matches.length - filteredMatches.length} wrong-year matches, keeping ${filteredMatches.length}`);
+        }
+
+        // Determine tournament status from filtered matches
+        const status = this.determineTournamentStatus(filteredMatches);
+
+        await TournamentMatchCache.cacheMatches(tournamentNo, filteredMatches, status, targetYear);
+        console.log(`✅ Warmed cache for tournament ${tournamentNo} year ${targetYear} (${filteredMatches.length} matches)`);
 
         // Non-blocking AuxiliaryPersons fetch for match officials (specs/006-match-officials-display - T015)
         // Fire-and-forget: Don't block tournament display on official data
@@ -192,15 +211,16 @@ export class TournamentCacheWarmingService {
   /**
    * Track recently viewed tournament for cache warming
    * @param tournamentNo - Tournament number that was viewed
+   * @param year - Tournament year (for date-scoped warming)
    */
-  static async trackRecentlyViewed(tournamentNo: string): Promise<void> {
+  static async trackRecentlyViewed(tournamentNo: string, year?: number): Promise<void> {
     try {
       const recent = await this.getRecentlyViewedTournaments();
 
       // Remove if already exists and add to front
       const filtered = recent.filter(t => t.tournamentNo !== tournamentNo);
       const updated: RecentTournament[] = [
-        { tournamentNo, lastViewed: new Date().toISOString() },
+        { tournamentNo, lastViewed: new Date().toISOString(), year: year || new Date().getFullYear() },
         ...filtered
       ].slice(0, this.MAX_RECENT_TOURNAMENTS);
 

--- a/services/cache/TournamentMatchCache.ts
+++ b/services/cache/TournamentMatchCache.ts
@@ -55,12 +55,31 @@ export class TournamentMatchCache {
         return null;
       }
 
+      // FIX #29: Validate that cached matches actually belong to the requested year
+      // Guards against corrupt cache entries from warming service or cross-year contamination
+      const validMatches = cached.matches.filter(m => {
+        const dateStr = (m as any).scheduledDateTime || (m as any).LocalDate;
+        if (!dateStr) return true; // Keep matches without dates (TBD)
+        return new Date(dateStr).getFullYear() === yearToUse;
+      });
+
+      if (validMatches.length !== cached.matches.length) {
+        console.warn(`⚠️ [Cache] Filtered ${cached.matches.length - validMatches.length} wrong-year matches from cache for tournament ${tournamentNo} year ${yearToUse}`);
+      }
+
+      if (validMatches.length === 0) {
+        // All matches were from wrong year - treat as cache miss
+        console.warn(`⚠️ [Cache] All ${cached.matches.length} cached matches are wrong year for tournament ${tournamentNo} year ${yearToUse}, treating as MISS`);
+        CachePerformanceMonitor.recordCacheMiss(cacheKey, Date.now() - startTime);
+        return null;
+      }
+
       const responseTime = Date.now() - startTime;
-      const dataSize = JSON.stringify(cached.matches).length;
+      const dataSize = JSON.stringify(validMatches).length;
 
       CachePerformanceMonitor.recordCacheHit(cacheKey, responseTime, dataSize);
-      console.log(`📦 ✅ Cache HIT for tournament ${tournamentNo} year ${yearToUse}`);
-      return cached.matches;
+      console.log(`📦 ✅ Cache HIT for tournament ${tournamentNo} year ${yearToUse} (${validMatches.length} matches)`);
+      return validMatches;
     } catch (error) {
       CachePerformanceMonitor.recordCacheError(cacheKey, Date.now() - startTime);
       console.warn('Failed to get cached matches:', error);

--- a/services/monitoring/AuditStorageService.ts
+++ b/services/monitoring/AuditStorageService.ts
@@ -9,6 +9,7 @@
  */
 
 import { MMKV } from 'react-native-mmkv';
+import { Platform } from 'react-native';
 import { ApiRequest, AuditFinding, AuditReport } from '../../types/audit';
 
 /**
@@ -43,7 +44,9 @@ export class AuditStorageService {
       // Initialize MMKV with audit namespace
       this.storage = new MMKV({
         id: 'audit-storage',
-        encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY,
+        ...(Platform.OS !== 'web' && process.env.EXPO_PUBLIC_MMKV_KEY
+          ? { encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY }
+          : {}),
       });
 
       // Clean up old data on initialization

--- a/services/notifications/NotificationPreferencesService.ts
+++ b/services/notifications/NotificationPreferencesService.ts
@@ -15,6 +15,7 @@
  */
 
 import { MMKV } from 'react-native-mmkv';
+import { Platform } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { supabase } from '../supabase';
 import type {
@@ -86,10 +87,12 @@ export class NotificationPreferencesService {
   private syncInterval: NodeJS.Timeout | null = null;
 
   private constructor() {
-    // Initialize MMKV with encryption
+    // Initialize MMKV — encryptionKey is NOT supported on web (react-native-mmkv)
     this.storage = new MMKV({
       id: STORAGE_NAMESPACE,
-      encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY || undefined
+      ...(Platform.OS !== 'web' && process.env.EXPO_PUBLIC_MMKV_KEY
+        ? { encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY }
+        : {})
     });
 
     this.log('NotificationPreferencesService initialized');

--- a/services/notifications/NotificationQueueService.ts
+++ b/services/notifications/NotificationQueueService.ts
@@ -13,6 +13,7 @@
  */
 
 import { MMKV } from 'react-native-mmkv';
+import { Platform } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import NotificationService from './NotificationService';
 import type { NotificationPayload } from '../../types/notifications';
@@ -69,7 +70,9 @@ export class NotificationQueueService {
   private constructor() {
     this.storage = new MMKV({
       id: 'notification_queue',
-      encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY || undefined
+      ...(Platform.OS !== 'web' && process.env.EXPO_PUBLIC_MMKV_KEY
+        ? { encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY }
+        : {})
     });
 
     this.log('NotificationQueueService initialized');

--- a/services/notifications/NotificationTriggerService.ts
+++ b/services/notifications/NotificationTriggerService.ts
@@ -14,6 +14,7 @@
  */
 
 import { MMKV } from 'react-native-mmkv';
+import { Platform } from 'react-native';
 import NotificationService from './NotificationService';
 import NotificationPreferencesService from './NotificationPreferencesService';
 import type {
@@ -69,7 +70,9 @@ export class NotificationTriggerService {
   private constructor() {
     this.storage = new MMKV({
       id: 'notification_triggers',
-      encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY || undefined
+      ...(Platform.OS !== 'web' && process.env.EXPO_PUBLIC_MMKV_KEY
+        ? { encryptionKey: process.env.EXPO_PUBLIC_MMKV_KEY }
+        : {})
     });
 
     this.log('NotificationTriggerService initialized');


### PR DESCRIPTION
## Summary
- Warming service now uses year-scoped API calls and filters wrong-year matches before caching
- Cache reads validate that matches belong to the requested year
- API responses are filtered by year before render and cache write
- Added `cache: 'no-store'` on VIS API fetch() to prevent browser HTTP cache serving stale data
- Fixed MMKV encryptionKey crash on web platform

## Test plan
- [ ] Open João Pessoa 2026 tournament on web — verify only 2026 matches shown
- [ ] Clear cache (`cacheDebug.clearAll()` + `localStorage.clear()`) and reload — verify correct data
- [ ] Check browser console for `[FIX-29]` logs if wrong-year data is intercepted
- [ ] Verify with next tournament this week

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)