### PR TITLE
ci: concedi pull-requests write al job deploy-preview

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -83,7 +83,17 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    
+
+    # Il default del repo per GITHUB_TOKEN e' read-only: senza questo blocco lo
+    # step di deploy riesce (il preview viene pubblicato) ma fallisce subito dopo
+    # con "Resource not accessible by integration" nel tentativo di postare il
+    # commento sulla PR, rendendo rossa ogni run `pull_request`.
+    # `actions: read` serve a download-artifact, `pull-requests: write` al commento.
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+
     steps:
     - name: Download build artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Rilevato durante #36.

## Problema

Ogni run su `pull_request` in questo repo è rossa, da sempre. Il deploy del preview **riesce** — il sito viene pubblicato regolarmente — ma lo step fallisce subito dopo mentre prova a postare il commento sulla PR:

```
🚀 Deployed on https://6a641576f786544cacd59ce6--beachrefs.netlify.app
##[error]Resource not accessible by integration
```

Il default del repo per `GITHUB_TOKEN` è read-only e il workflow non dichiarava alcun blocco `permissions`, quindi `nwtgck/actions-netlify` non può scrivere il commento.

Verificato sui run di #34, #32, #29, #27 e #37: **tutti** falliti sullo stesso step, **tutti** con il deploy riuscito. Il risultato pratico è che la CI rossa non voleva dire niente, e questo maschera i fallimenti veri.

## Fix

Blocco `permissions` sul solo job `deploy-preview`, con i permessi minimi:

- `pull-requests: write` → postare il commento
- `actions: read` → `download-artifact`
- `contents: read` → default di lettura

Il job `deploy` (push su master) **non è toccato**: funziona già e aggiungergli un blocco `permissions` restringerebbe i suoi default senza motivo.

## Verifica

Questa PR è la verifica: il job `deploy-preview` gira proprio sugli eventi `pull_request`. Se il fix funziona, questa run è la prima verde della storia del repo e sotto compare il commento automatico di Netlify.