### PR TITLE
fix(notifications): un solo export per i servizi singleton — init notifiche rotto a ogni avvio (#43)

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -83,6 +83,23 @@
 - **Database**: Supabase dashboard query performance analysis
 - **Build Failures**: Check EAS build logs + dependency conflicts
 
+## Convenzione singleton dei servizi (issue #43)
+
+Un servizio singleton espone **solo la classe come named export**. È vietato
+aggiungere `export default X.getInstance()` (o qualunque default che sia
+un'istanza già costruita) accanto alla classe omonima: il consumer scrive
+`import X from '...'`, crede di avere la classe, chiama il metodo statico
+`X.getInstance()` sull'istanza e ottiene a runtime
+`X.default.getInstance is not a function`. Uso corretto:
+
+```ts
+import { NotificationService } from '../services/notifications/NotificationService';
+const service = NotificationService.getInstance();
+```
+
+Il contratto è verificato dai test in
+`__tests__/services/notifications/NotificationServiceInit.test.ts`.
+
 ## Backlog
 - **TODO**: Integrazione AI per analisi performance arbitri
 - **TODO**: Offline mode per gestione tornei senza connessione
@@ -101,6 +118,7 @@
 - **DONE**: Issue #36 (PR #37) — Web perf cache/SW: rimosso `Clear-Site-Data: "cache"` (azzerava la cache HTTP a ogni risposta), **`public/_headers` unica fonte di verità** per header e redirect (`public/_redirects` eliminato col catch-all SPA `/* → /index.html` che rompeva il per-route SSG di #34; `netlify.toml` svuotato perché **inerte** — vedi sezione sotto), chunk `/_expo/*` ora davvero `immutable`, service worker senza handler `fetch` e senza `caches.delete()` indiscriminato, latency probe di `NetworkStateManager` spostata dal documento HTML a `HEAD /favicon.ico` fuori dal percorso critico. Misurato sul deploy: contenuto reale da ~9900 ms a ~2277 ms, TTFB da 2046 ms a 152 ms, prima chiamata VIS API da 8275 ms a 1322 ms. Test: `tests/curl-tests.sh <BASE_URL>` (15 check), `npm run test:prerender`
 - **TODO**: Issue #38 (follow-up di #36) — dimagrimento del bundle `entry-*.js` (868 KB br / 3.7 MB raw): dopo #36 è il **95% dell'LCP residuo** (2115 ms di render delay su 2187 ms di LCP, con TTFB a 72 ms). Chiude i due target LCP lasciati aperti da #36
 - **DONE**: Issue #40 — `services/OfficialsService.ts`: nomi di scorer/assistant scorer/line judge per match e delegazione arbitrale, **2 chiamate VIS per torneo** indipendenti dal numero di match. Decoding XML-nell'XML isolato in `utils/visEmbeddedXml.ts`, tipi in `types/referee-v2.ts`, 26 test su fixture reali senza rete, script `scripts/show-tournament-officials.js`. Fix collaterale: `GetEventRefereeList` in `VisApiClient` era rotto (mancava l'envelope `<Requests>`). Limite documentato: referee coach e technical delegate non ottenibili dalla VIS pubblica
+- **DONE**: Issue #43 — Notifiche: l'init falliva a **ogni** avvio in produzione (`TypeError: w.default.getInstance is not a function`, degradato a warning dal try/catch di init). Causa: i 5 servizi in `services/notifications/` esportavano sia la classe (named) sia un `export default X.getInstance()` — cioè un'**istanza già costruita** con lo stesso nome — e i consumer importavano il default chiamandoci sopra il metodo **statico** `getInstance()`. Convenzione adottata: **solo named export della classe, nessun default export**; 13 file allineati (5 servizi + 8 consumer, incluso `NotificationService` stesso che usava male `WebPushService`). Aggiunto `NotificationService.isInitialized()` come prova positiva di init e log dedicati in `app/_layout.tsx`; l'init error è ora `console.error` in `__DEV__` (il warn silenzioso è ciò che ha nascosto il bug). Test: `__tests__/services/notifications/NotificationServiceInit.test.ts` (22 test, 19 falliscono col bug presente)
 - **TODO** (epic, se prioritizzato): Web perf −80% architetturale — Expo output `server` con data fetching, o rimozione runtime pesante (reanimated)
 
 ## Web — configurazione cache e redirect (issue #36)

--- a/__tests__/services/notifications/NotificationServiceInit.test.ts
+++ b/__tests__/services/notifications/NotificationServiceInit.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for issue #43.
+ *
+ * Bug: `services/notifications/*Service.ts` exported BOTH a named class and a
+ * default that was an already-built instance (`export default X.getInstance()`).
+ * Consumers imported the default and called the *static* `getInstance()` on it,
+ * which blew up at every app start with:
+ *   TypeError: w.default.getInstance is not a function
+ * The error was swallowed by the init try/catch and degraded to a warning, so
+ * the whole notification subsystem was dead in production without any signal.
+ *
+ * These tests fail if the default-instance export (or a default import of it)
+ * is ever reintroduced.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notif-id')),
+  dismissAllNotificationsAsync: jest.fn(() => Promise.resolve()),
+  setBadgeCountAsync: jest.fn(() => Promise.resolve()),
+  getBadgeCountAsync: jest.fn(() => Promise.resolve(0)),
+  openSettingsAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  AndroidNotificationPriority: { HIGH: 'high', DEFAULT: 'default' },
+}));
+
+jest.mock('expo-device', () => ({
+  isDevice: true,
+  deviceName: 'jest',
+  osVersion: '1.0',
+}));
+
+// babel-preset-expo rewrites `process.env.EXPO_PUBLIC_*` into an import from
+// the ESM-only `expo/virtual/env`, which the project's jest transform cannot
+// handle (issue #48). Stubbed here rather than fixing the global config.
+jest.mock('expo/virtual/env', () => ({ env: process.env }));
+
+// The project's jest config cannot transform the Expo/React Native ESM entry
+// points (see issue #48), so react-native is stubbed down to what this service
+// actually uses.
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  Alert: { alert: jest.fn() },
+}));
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+}));
+const routerPush = require('expo-router').router.push as jest.Mock;
+
+const ROOT = path.resolve(__dirname, '../../..');
+
+const SERVICE_FILES = [
+  'services/notifications/NotificationService.ts',
+  'services/notifications/WebPushService.ts',
+  'services/notifications/NotificationTriggerService.ts',
+  'services/notifications/NotificationQueueService.ts',
+  'services/notifications/NotificationPreferencesService.ts',
+];
+
+// Every file that consumes one of the notification singletons.
+const CONSUMER_FILES = [
+  'app/_layout.tsx',
+  'app/notification-settings.tsx',
+  'components/notifications/NotificationTestPanel.tsx',
+  'hooks/useNotificationPermissions.ts',
+  'hooks/useNotificationPreferences.ts',
+  'services/AssignmentStatusService.ts',
+  'services/RealtimeSubscriptionService.ts',
+  'services/RefereeAssignmentsService.ts',
+  'services/notifications/NotificationService.ts',
+  'services/notifications/NotificationTriggerService.ts',
+  'services/notifications/NotificationQueueService.ts',
+];
+
+const SERVICE_NAMES = [
+  'NotificationService',
+  'WebPushService',
+  'NotificationTriggerService',
+  'NotificationQueueService',
+  'NotificationPreferencesService',
+];
+
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+describe('issue #43 - notification singleton export contract', () => {
+  it.each(SERVICE_FILES)(
+    '%s does not export a pre-built instance as default',
+    (rel) => {
+      const source = read(rel);
+      // `export default X.getInstance()` is the exact shape that caused the bug.
+      expect(source).not.toMatch(/export default\s+\w+\.getInstance\(\)/);
+      // ...and no default export at all, so `import X from` can never silently
+      // resolve to an instance while looking like the class.
+      expect(source).not.toMatch(/^export default /m);
+    }
+  );
+
+  it.each(CONSUMER_FILES)(
+    '%s imports notification services as named class exports',
+    (rel) => {
+      const source = read(rel);
+      for (const name of SERVICE_NAMES) {
+        // A default import of a notification service is forbidden: it is what
+        // made `NotificationService.getInstance()` resolve to an instance.
+        const defaultImport = new RegExp(
+          `^import\\s+${name}\\s*(,|from)`,
+          'm'
+        );
+        expect(source).not.toMatch(defaultImport);
+      }
+    }
+  );
+});
+
+describe('issue #43 - NotificationService initialization', () => {
+  // Loaded lazily so the jest.mock factories above are in place.
+  const load = () =>
+    require('../../../services/notifications/NotificationService');
+
+  it('exposes no default export (nothing to accidentally call statically)', () => {
+    const mod = load();
+    expect(mod.default).toBeUndefined();
+  });
+
+  it('exposes the class as a named export with a static getInstance()', () => {
+    const { NotificationService } = load();
+    expect(typeof NotificationService).toBe('function');
+    expect(typeof NotificationService.getInstance).toBe('function');
+  });
+
+  it('getInstance() returns an instance, not something with getInstance()', () => {
+    const { NotificationService } = load();
+    const instance = NotificationService.getInstance();
+    expect(instance).toBeInstanceOf(NotificationService);
+    // The bug in a nutshell: the default export was THIS object, and callers
+    // did `default.getInstance()` on it.
+    expect((instance as any).getInstance).toBeUndefined();
+  });
+
+  it('returns the same singleton on repeated calls', () => {
+    const { NotificationService } = load();
+    expect(NotificationService.getInstance()).toBe(
+      NotificationService.getInstance()
+    );
+  });
+
+  it('initialize() completes and reports isInitialized() === true', async () => {
+    const Notifications = require('expo-notifications');
+    const { NotificationService } = load();
+    const service = NotificationService.getInstance();
+    service.reset();
+
+    expect(service.isInitialized()).toBe(false);
+    await service.initialize();
+    expect(service.isInitialized()).toBe(true);
+    expect(Notifications.setNotificationHandler).toHaveBeenCalled();
+  });
+
+  it('reproduces the app/_layout.tsx consumption path end to end', async () => {
+    const Notifications = require('expo-notifications');
+    const { NotificationService } = load();
+
+    // 1. init, exactly as app/_layout.tsx does it
+    const notificationService = NotificationService.getInstance();
+    notificationService.reset();
+    await notificationService.initialize();
+    expect(notificationService.isInitialized()).toBe(true);
+
+    // 2. register the response listener, exactly as app/_layout.tsx does it
+    routerPush.mockClear();
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      (response: any) => {
+        NotificationService.getInstance().handleNotificationResponse(response);
+      }
+    );
+    expect(subscription).toBeDefined();
+
+    // 3. the registered handler must actually route a tapped notification
+    const handler =
+      Notifications.addNotificationResponseReceivedListener.mock.calls.at(-1)[0];
+    handler({
+      notification: {
+        request: {
+          content: {
+            data: { type: 'status_change' },
+          },
+        },
+      },
+    });
+    expect(routerPush).toHaveBeenCalledWith('/referee-dashboard');
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,7 @@ import { enablePerformanceMonitoring } from "../lib/queryPerformance";
 import { asyncStoragePersister, handlePersistenceError, migrateAsyncStorageData } from "../lib/queryPersistence";
 import { TournamentCacheWarmingService } from "../services/cache/TournamentCacheWarmingService";
 import { CacheMigrationService } from "../services/cache/CacheMigrationService";
-import NotificationService from "../services/notifications/NotificationService";
+import { NotificationService } from "../services/notifications/NotificationService";
 import { injectCSSVariables } from "../theme/css-variables";
 import { colors } from "../theme/tokens";
 
@@ -133,13 +133,24 @@ export default function RootLayout() {
         // Initialize notification service
         const notificationService = NotificationService.getInstance();
         await notificationService.initialize();
-        console.log('Notification service initialized');
+        // Positive proof the subsystem is actually live (issue #43, AC2):
+        // before the fix this line was never reached — getInstance() threw.
+        console.log(
+          '[App] Notification service initialized:',
+          notificationService.isInitialized()
+        );
 
         // Performance monitoring and data persistence handled by queryClient
 
       } catch (error) {
-        // Handle initialization errors gracefully
-        console.warn('App initialization warning:', error);
+        // Handle initialization errors gracefully at runtime, but make them
+        // loud in development: a silent console.warn here is what hid issue #43
+        // (broken notification init) for months.
+        if (__DEV__) {
+          console.error('App initialization FAILED:', error);
+        } else {
+          console.warn('App initialization warning:', error);
+        }
       }
       console.log('App initialization completed');
     };
@@ -159,6 +170,7 @@ export default function RootLayout() {
     const subscription = Notifications.addNotificationResponseReceivedListener(response => {
       NotificationService.getInstance().handleNotificationResponse(response);
     });
+    console.log('[App] Notification response listener registered');
 
     return () => {
       subscription.remove();

--- a/app/notification-settings.tsx
+++ b/app/notification-settings.tsx
@@ -20,8 +20,8 @@ import {
 } from 'react-native';
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import NotificationService, { PermissionStatus } from '../services/notifications/NotificationService';
-import NotificationPreferencesService from '../services/notifications/NotificationPreferencesService';
+import { NotificationService, PermissionStatus } from '../services/notifications/NotificationService';
+import { NotificationPreferencesService } from '../services/notifications/NotificationPreferencesService';
 import type { NotificationPreferences } from '../types/notifications';
 import { useTheme } from '../theme/ThemeContext';
 import Container from '../components/Foundation/Container';

--- a/components/notifications/NotificationTestPanel.tsx
+++ b/components/notifications/NotificationTestPanel.tsx
@@ -17,9 +17,9 @@ import {
   Alert
 } from 'react-native';
 import { useTheme } from '../../theme/ThemeContext';
-import NotificationService from '../../services/notifications/NotificationService';
-import NotificationTriggerService from '../../services/notifications/NotificationTriggerService';
-import NotificationQueueService from '../../services/notifications/NotificationQueueService';
+import { NotificationService } from '../../services/notifications/NotificationService';
+import { NotificationTriggerService } from '../../services/notifications/NotificationTriggerService';
+import { NotificationQueueService } from '../../services/notifications/NotificationQueueService';
 import type { NotificationType } from '../../types/notifications';
 
 interface NotificationTestPanelProps {

--- a/hooks/useNotificationPermissions.ts
+++ b/hooks/useNotificationPermissions.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import NotificationService, { PermissionStatus } from '../services/notifications/NotificationService';
+import { NotificationService, PermissionStatus } from '../services/notifications/NotificationService';
 
 /**
  * Hook return type

--- a/hooks/useNotificationPreferences.ts
+++ b/hooks/useNotificationPreferences.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import NotificationPreferencesService from '../services/notifications/NotificationPreferencesService';
+import { NotificationPreferencesService } from '../services/notifications/NotificationPreferencesService';
 import type { NotificationPreferences } from '../types/notifications';
 
 /**

--- a/services/AssignmentStatusService.ts
+++ b/services/AssignmentStatusService.ts
@@ -5,8 +5,8 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert, Vibration } from 'react-native';
-import NotificationService from './notifications/NotificationService';
-import NotificationPreferencesService from './notifications/NotificationPreferencesService';
+import { NotificationService } from './notifications/NotificationService';
+import { NotificationPreferencesService } from './notifications/NotificationPreferencesService';
 import { NotificationType } from '../types/notifications';
 
 // Simple EventEmitter implementation for React Native compatibility

--- a/services/RealtimeSubscriptionService.ts
+++ b/services/RealtimeSubscriptionService.ts
@@ -5,7 +5,7 @@ import { AppState } from 'react-native';
 import { RealtimePerformanceMonitor, ConnectionState } from './RealtimePerformanceMonitor';
 import { RealtimeFallbackService } from './RealtimeFallbackService';
 import { ConnectionCircuitBreaker, CircuitState } from './ConnectionCircuitBreaker';
-import NotificationTriggerService from './notifications/NotificationTriggerService';
+import { NotificationTriggerService } from './notifications/NotificationTriggerService';
 import RefereeAssignmentsService from './RefereeAssignmentsService';
 
 // Subscription configuration

--- a/services/RefereeAssignmentsService.ts
+++ b/services/RefereeAssignmentsService.ts
@@ -5,7 +5,7 @@ import { VisApiClient } from './api/VisApiClient';
 import { DEFAULT_RETRY_CONFIG } from '../types/api-v2';
 import { CacheServiceCompatibility as CacheService } from '../hooks/compatibility/CacheServiceCompatibility';
 import { TournamentRefereeData, getOfficialDisplayName, isActiveOfficial, OfficialStatus, OfficialType } from '../types/referee-v2';
-import NotificationTriggerService from './notifications/NotificationTriggerService';
+import { NotificationTriggerService } from './notifications/NotificationTriggerService';
 
 export class RefereeAssignmentsService {
   private static readonly REFEREE_PROFILE_KEY = '@referee_profile';

--- a/services/notifications/NotificationPreferencesService.ts
+++ b/services/notifications/NotificationPreferencesService.ts
@@ -737,5 +737,9 @@ export class NotificationPreferencesService {
   }
 }
 
-// Export singleton instance
-export default NotificationPreferencesService.getInstance();
+// NOTE (issue #43): intentionally NO default export.
+// A default export holding an already-built instance coexisting with a
+// same-named class export is what caused `X.default.getInstance is not a
+// function` at runtime. Consume this service as:
+//   import { NotificationPreferencesService } from '.../NotificationPreferencesService';
+//   NotificationPreferencesService.getInstance()

--- a/services/notifications/NotificationQueueService.ts
+++ b/services/notifications/NotificationQueueService.ts
@@ -15,7 +15,7 @@
 import { MMKV } from 'react-native-mmkv';
 import { Platform } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
-import NotificationService from './NotificationService';
+import { NotificationService } from './NotificationService';
 import type { NotificationPayload } from '../../types/notifications';
 
 /**
@@ -385,5 +385,9 @@ export class NotificationQueueService {
   }
 }
 
-// Export singleton instance
-export default NotificationQueueService.getInstance();
+// NOTE (issue #43): intentionally NO default export.
+// A default export holding an already-built instance coexisting with a
+// same-named class export is what caused `X.default.getInstance is not a
+// function` at runtime. Consume this service as:
+//   import { NotificationQueueService } from '.../NotificationQueueService';
+//   NotificationQueueService.getInstance()

--- a/services/notifications/NotificationService.ts
+++ b/services/notifications/NotificationService.ts
@@ -17,7 +17,7 @@ import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import { Platform, Alert } from 'react-native';
 import { router } from 'expo-router';
-import WebPushService from './WebPushService';
+import { WebPushService } from './WebPushService';
 import type {
   NotificationPayload,
   NotificationType,
@@ -535,6 +535,14 @@ export class NotificationService {
   }
 
   /**
+   * Whether initialize() has completed successfully.
+   * Positive proof that the notification subsystem is live (issue #43, AC2).
+   */
+  public isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
    * Reset service (for testing)
    */
   public reset(): void {
@@ -544,5 +552,9 @@ export class NotificationService {
   }
 }
 
-// Export singleton instance
-export default NotificationService.getInstance();
+// NOTE (issue #43): intentionally NO default export.
+// A default export holding an already-built instance coexisting with a
+// same-named class export is what caused `w.default.getInstance is not a
+// function` at every app start. Consume this service as:
+//   import { NotificationService } from '.../NotificationService';
+//   NotificationService.getInstance()

--- a/services/notifications/NotificationTriggerService.ts
+++ b/services/notifications/NotificationTriggerService.ts
@@ -15,8 +15,8 @@
 
 import { MMKV } from 'react-native-mmkv';
 import { Platform } from 'react-native';
-import NotificationService from './NotificationService';
-import NotificationPreferencesService from './NotificationPreferencesService';
+import { NotificationService } from './NotificationService';
+import { NotificationPreferencesService } from './NotificationPreferencesService';
 import type {
   NotificationType,
   NotificationPayload,
@@ -604,5 +604,9 @@ export class NotificationTriggerService {
   }
 }
 
-// Export singleton instance
-export default NotificationTriggerService.getInstance();
+// NOTE (issue #43): intentionally NO default export.
+// A default export holding an already-built instance coexisting with a
+// same-named class export is what caused `X.default.getInstance is not a
+// function` at runtime. Consume this service as:
+//   import { NotificationTriggerService } from '.../NotificationTriggerService';
+//   NotificationTriggerService.getInstance()

--- a/services/notifications/WebPushService.ts
+++ b/services/notifications/WebPushService.ts
@@ -361,4 +361,9 @@ export class WebPushService {
 }
 
 // Export singleton instance
-export default WebPushService.getInstance();
+// NOTE (issue #43): intentionally NO default export.
+// A default export holding an already-built instance coexisting with a
+// same-named class export is what caused `X.default.getInstance is not a
+// function` at runtime. Consume this service as:
+//   import { WebPushService } from '.../WebPushService';
+//   WebPushService.getInstance()


### PR DESCRIPTION
Closes #43 — parte dell'epic #51 (Wave 0).

## Causa

I 5 servizi in `services/notifications/` esportavano **due cose con lo stesso nome**: la classe come named export e `export default X.getInstance()`, cioè un'**istanza già costruita**. I consumer facevano `import X from '...'`, credevano di avere la classe e chiamavano il metodo *statico* `X.getInstance()` sull'istanza:

```
[warn] App initialization warning: TypeError: w.default.getInstance is not a function
```

Il try/catch di init in `app/_layout.tsx` degradava l'errore a `console.warn`, quindi l'intero sottosistema notifiche era morto in produzione senza alcun segnale.

## Fix — convenzione, non toppa

**Solo named export della classe, nessun default export** (AC4). L'ambiguità è rimossa alla radice, non è stata aggiustata la singola chiamata. Ogni servizio porta un commento che spiega perché il default export non deve tornare.

13 file allineati: i 5 servizi (`NotificationService`, `WebPushService`, `NotificationTriggerService`, `NotificationQueueService`, `NotificationPreferencesService`) e 8 consumer.

**Bug collaterale trovato, non citato nella issue**: `NotificationService` stesso importava `WebPushService` come default e ne chiamava `getInstance()` in 5 punti — stesso identico bug, rompeva l'intero percorso web di permessi, registrazione push, invio e clear delle notifiche. Sistemato nello stesso commit perché è la stessa causa.

## Prova positiva che l'init funziona (AC2)

Aggiunto `NotificationService.isInitialized()` e in `app/_layout.tsx`:

```
[App] Notification service initialized: true
[App] Notification response listener registered
```

Il primo log **non era raggiungibile** prima del fix: `getInstance()` esplodeva una riga sopra.

Cambiato inoltre il `console.warn` dell'init in `console.error` **solo in `__DEV__`**: è esattamente quel warn silenzioso che ha nascosto il bug per mesi. In produzione resta `warn` per non cambiare comportamento.

## Test (AC5)

`__tests__/services/notifications/NotificationServiceInit.test.ts` — 22 test:

- contratto statico: nessuno dei 5 servizi ha un default export, nessuno degli 11 file consumer li importa come default
- contratto runtime: il modulo non espone `default`; la classe è named con `getInstance()` statico; l'istanza restituita **non** ha `getInstance()` (il cuore del bug)
- funzionale: `initialize()` completa e `isInitialized()` torna `true`
- integrazione: riproduce il percorso di `app/_layout.tsx` end to end, registrazione del listener compresa, e verifica che `handleNotificationResponse` instradi davvero la navigazione

**Verificato che fallisce col bug presente** (`git stash` del solo codice, test invariato):

| | col bug | col fix |
|---|---|---|
| Test | **19 failed**, 3 passed | **22 passed** |

## AC6 — ricerca su tutta la codebase

`export default X.getInstance()`: **5 occorrenze, tutte nei servizi notifiche, tutte rimosse. Nessun'altra nel progetto.**

Cercati anche i pattern adiacenti:
- `export default new X()` → **0 occorrenze**
- `export default <istanza minuscola>` → 25 occorrenze, tutte innocue: 20 sono hook (funzioni), 3 sono `meta` di Storybook, `services/api/visApi.ts` è un object literal senza statici e `services/supabase.ts` è un client. Nessuna ha chiamate statiche a valle.

## Numeri vs master

| | master | branch |
|---|---|---|
| `npm test` | 187 failed / 942 passed / 1129 | 187 failed / **964** passed / 1151 |
| Suite fallite | 118 | **117** |
| `npx tsc --noEmit` | 4248 righe | **4214** |
| `npm run lint` | 5 errori, 917 warning | 5 errori, 917 warning (identici, nessuno nei file toccati) |

Zero nuovi fallimenti. Le suite fallite scendono di una pur aggiungendone una nuova: `AssignmentStatusService` non esplode più all'import. Le 34 righe di `tsc` in meno sono errori che il default-import di un'istanza generava.

## Nota

Il test mocka `expo/virtual/env` e `react-native` localmente: la config jest del progetto non transpila gli entry point ESM di Expo (**issue #48**, già aperta). Aggiramento minimo e circoscritto al file di test, non risolto qui.

## AC

| AC | Stato |
|---|---|
| AC1 — nessun warning all'avvio | ✅ da verificare a schermo sul deploy preview |
| AC2 — init davvero completata, prova positiva | ✅ `isInitialized()` + log + test |
| AC3 — 5 file consumer verificati | ✅ (in realtà 8 + i servizi stessi) |
| AC4 — ambiguità rimossa alla radice | ✅ nessun default export, convenzione in PROJECT.md |
| AC5 — test che fallisce col bug | ✅ 19/22 falliscono col bug presente |
| AC6 — ricerca su tutta la codebase | ✅ vedi sopra |
| AC7 — lint/tsc/test in parità | ✅ vedi tabella |

PROJECT.md aggiornato (backlog + sezione "Convenzione singleton dei servizi").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtgSgoMNymU1g6osFv7oFc
