### PR TITLE
refactor(app): togli le 13 fetch dirette al VIS dalle 4 schermate in app/ (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ The project uses Expo Router with a comprehensive screen-based navigation system
 - `NetworkMonitor.ts` - Network connectivity monitoring
 
 **Business Logic Services**:
+- `RefereeDirectoryService.ts` - Referee directory reads for the `app/` screens
+  (issue #46). **The screens must not talk to the VIS themselves.** Until #46,
+  `tournament-ref`, `all-referees`, `ref-mode` and `referee-profile` issued 13
+  raw `fetch` calls to `fivb.org` from inside the component body, which bypassed
+  retry, the request monitor and — the part that actually mattered —
+  `ApiAuditService`, so the API conformance numbers in this file were blind to
+  that traffic. Every read is now cached per key and routed through
+  `VisApiClient`. If you need a referee-shaped datum in a screen, add a method
+  here rather than a `fetch` there.
 - `RefereeAssignmentsService.ts` - Assignment management
 - `MatchResultsService.ts` - Match result handling
 - `TournamentOperationsService.ts` - Tournament operations

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -73,6 +73,11 @@
   torneo (scorer, assistant scorer, line judge) e delegazione arbitrale, dalla VIS.
   Costo **2 chiamate per torneo**, indipendente dal numero di match. Vedi sezione
   "Officials di torneo" più sotto.
+- **RefereeDirectoryService** (`services/RefereeDirectoryService.ts`): anagrafica
+  arbitri per la UI — roster di evento, direttorio globale, singolo arbitro,
+  officials di evento, ritratto e ID card. È l'unico punto da cui le schermate
+  in `app/` leggono questi dati; tutto passa da `VisApiClient` ed è cachato per
+  chiave (issue #46). Vedi sezione "Anagrafica arbitri" più sotto.
 
 ## Monitoring
 - **Health Check**: App startup + API connectivity check
@@ -162,6 +167,7 @@ Guida completa (DI, `fetch` finto, timer, formato del body VIS):
 - **DONE**: Issue #52 (epic #51, decisione 1 di #50) — Un solo sistema pubblica il sito. Fino a oggi il web era deployato **due volte a ogni push**: dalla GitHub Action (`nwtgck/actions-netlify`, che vinceva la corsa — era il suo artifact quello che vedevano gli utenti) e in parallelo dall'integrazione git di Netlify, di cui sulle PR si vedevano solo i check. Rimossi i job `deploy` e `deploy-preview`; il job `build` **resta** come gate sulle PR (perdere la verifica "compila?" sarebbe stato un regresso) e il workflow è stato rinominato `netlify-deploy.yml` → **`web-build.yml`**, con il job id `build` invariato. Conseguenza non ovvia: Netlify **checkouta la repo**, quindi `netlify.toml` da inerte diventa **letto** — i commenti in `netlify.toml` e `public/_headers` che spiegavano perché era inerte sono stati riscritti, perché da oggi mentono. Gli header **restano in `public/_headers`**: spostarli in `netlify.toml` ora che verrebbe letto sarebbe una seconda migrazione senza beneficio e un secondo posto dove sbagliare l'ordinamento. `NODE_VERSION = "18"` dichiarato esplicitamente in `netlify.toml` (allineato a `.nvmrc` e al workflow). **Env var: nessuna necessaria** — verificato scaricando i due bundle `entry-*.js`, quello di produzione (buildato dalla Action) e quello del deploy Netlify-nativo della PR #59: **zero** occorrenze di URL Supabase o chiavi in entrambi, dimensioni entro lo 0,02% — la Action non passava alcuna `EXPO_PUBLIC_*` e Netlify non ne ha configurate, quindi il bundle pubblicato non cambia. Prova che l'integrazione Netlify regge: `tests/curl-tests.sh` sul permalink del deploy Netlify-nativo della PR #59 → **15/15 verdi** (chunk `_expo` `immutable`, HTML `no-store`, nessun `Clear-Site-Data`, SSG per-rotta). ⚠️ I secret GitHub `NETLIFY_AUTH_TOKEN` e `NETLIFY_SITE_ID` non sono più usati da nulla: **revocarli** è a carico di Davide. `docs/DEPLOYMENT_SETUP.md` riscritto (descriveva i secret della Action e attribuiva a `netlify.toml` redirect SPA e header di sicurezza mai esistiti)
 - **DONE**: Issue #45 (epic #51, wave 1, propedeutica a #38) — Codice morto e codice dormiente sono due cose diverse, e la issue le trattava insieme. **Morto e rimosso**: `IntegrationTestSuite` + `MigrationOrchestrationService` + `MigrationMonitoringService` + `MigrationRollbackService` (127 KB di sorgente, 5933 righe) formavano un'**isola chiusa** — si importavano solo fra loro, la radice `IntegrationTestSuite` non era importata da nessuno tranne il proprio test, e nessun percorso da `app/` li raggiungeva. Verificati anche i riferimenti dinamici (nessun `require()` a runtime, nessun import per stringa, nessuna citazione in `package.json`/`.github/`/`.husky/`/`netlify.toml`/`app.json`/script; `scripts/enableMigration.js`, che il nome suggerirebbe, riguarda i feature flag degli hook). **Effetto sul bundle: zero, e misurato** — non essendo nel grafo di build non erano nel chunk `entry-*.js`: 0 occorrenze di ogni marker nel bundle prodotto *prima* della rimozione. I "170 KB nel grafo di build" della issue erano sorgente su disco, non peso spedito. **Dormiente e mantenuto**: `DualReadService` **non** è stato rimosso (AC3 opzione (b)) perché la #54 accende Supabase sul web e questo è il percorso DB-first che piloterà. È stato reso **davvero** lazy: l'accesso avveniva con un `require()` dentro un metodo, ma **Metro risolve `require()` staticamente esattamente come `import`** — differiva l'*esecuzione*, mai il *caricamento*, quindi il file stava nell'entry. Con `import()` dinamico memoizzato: entry raw 3.666.774 → 3.641.546 B (**−25.228 B, −0,69%**), br 711.719 → 707.711 B (**−4.008 B, −0,56%**), nuovo chunk `DualReadService-*.js` raw 25.704 / br 5.425 B (23 → 24 chunk). `@supabase/supabase-js` **non** si sposta: resta nell'entry perché lo importano altri 8 moduli raggiungibili da `app/`. **Scoperta collaterale importante per la #54**: il ramo DB non "fallisce e degrada", è il **costruttore** che esplode — senza `EXPO_PUBLIC_SUPABASE_URL` `createClient()` lancia `supabaseUrl is required.`, quindi ogni `getTournaments`/`getMatches`/`getReferees`/`clearCache` di `CacheServiceCompatibility` termina nel `catch` dei chiamanti sulla VIS API. Appena le variabili saranno su Netlify, `readStrategy: 'db_first'` si attiva **di colpo** su tutte e quattro le strade, senza altri interruttori. tsc 2675 → **2603** (−72), lint 922 (5 errori) invariato, 4 suite rosse in meno, `npm run audit:ci` PASS
 - **TODO** (emerso da #45): `services/DataConsistencyValidator.ts` e `services/DataSyncService.ts` sono **rimasti orfani** dopo la rimozione della catena `Migration*` — erano importati solo da lì. Non eliminati di proposito: sono codice Supabase e vanno valutati insieme alla #54, non tagliati di nascosto
+- **DONE**: Issue #46 (epic #51, wave 2, parte 1 di 2) — Le **13 `fetch` dirette al VIS** nelle 4 schermate di `app/` (`tournament-ref` 5, `all-referees` 3, `ref-mode` 3, `referee-profile` 2) sono state sostituite da `services/RefereeDirectoryService.ts`, modellato su `OfficialsService`. Non è solo estetica: bypassare `VisApiClient` significava bypassare retry, monitor e soprattutto `ApiAuditService` — le metriche di conformità API in CLAUDE.md **non vedevano questo traffico**, ed è questa la ragione vera della issue. Aggiunti al client 4 endpoint che prima esistevano solo come stringhe XML nei componenti (`GetRefereeList`, `GetReferee`, `GetImageList`, `GetRefereeIdCard`), ciascuno con l'envelope `<Requests>` che questi endpoint richiedono (senza, rispondono `<NotInNewFormat id="1008" />` — stessa trappola di `GetEventRefereeList` trovata nella #40). **Misura AC5**: `tournament-ref` chiedeva **tre volte** lo stesso `GetEventRefereeList` in un solo caricamento; ora aprire → tornare indietro → riaprire costa **2 chiamate invece di 8** (−75%), `all-referees` scarica il direttorio globale **una volta invece di due**, `ref-mode` passa da 4 chiamate a 3 e da 3 a 1 alla riapertura. 29 test nuovi su fixture **senza rete**. tsc 2603 → **2593**, lint 922 → **918** (5 errori invariati, tutti preesistenti in file non toccati), `audit:ci` PASS. **Due bug preesistenti trovati e NON corretti** (la issue è un refactoring): (1) `ref-mode` chiude il caricamento con una `GetEvent` che **sovrascrive** le liste appena ottenute con quello che riesce a estrarne — e non estrae nulla, perché `GetEvent` non risponde con `<EventOfficialList>`/`<EventRefereeList>`: è il motivo per cui la schermata mostra `Officials (0) / Referees (0)` ed è "under construction"; il comportamento è preservato alla lettera con un commento che lo marca. (2) `all-referees` fa fan-out con `Promise.all` **non limitato** di una richiesta statistiche per ogni arbitro attivo — vedi issue #65
 - **TODO**: Rientro del baseline `.audit-baseline.json` verso zero (2721 finding bloccanti: 2677 TS, 5 ESLint error, 39 error-handling; **0 Critical, 0 security**)
 
 ## Il peso del bundle non è la leva dell'LCP (issue #38)
@@ -369,6 +375,59 @@ API + cache, non DB. Per persistere servirebbero `event_officials` e
 `match_officials` popolate dalle stesse 2 chiamate — ma il prerequisito è
 valorizzare le credenziali nel deploy.
 
+## Anagrafica arbitri (issue #46)
+
+`services/RefereeDirectoryService.ts` è **l'unico** punto da cui le schermate in
+`app/` leggono l'anagrafica arbitri. Prima della #46 le quattro schermate
+parlavano con `fivb.org` da dentro il corpo del componente, con 13 `fetch`.
+
+### Perché non era solo brutto
+
+`ApiAuditService` misura **solo ciò che passa da `VisApiClient`**. Le percentuali
+di payload reduction, cache hit rate e call volume riportate in CLAUDE.md erano
+quindi **cieche** su tutto questo traffico. Tre schermate su quattro non avevano
+cache e rifacevano ogni richiesta a ogni montaggio.
+
+### Chi chiede cosa
+
+| Metodo | Chiamata VIS | Chiave cache | TTL |
+|---|---|---|---|
+| `getEventReferees` | `GetEventRefereeList` | `referees:event:<eventNo>` | 120 s |
+| `getEventOfficials` | `GetEventOfficialList` | `referees:event-officials:<eventNo>` | 120 s |
+| `getEventMatches` | `GetBeachMatchList` | `referees:event-matches:<eventNo>` | 15 s |
+| `getAllReferees` | `GetRefereeList` | `referees:all:<sport>` | 120 s |
+| `getReferee` | `GetReferee` | `referees:one:<no>` | 120 s |
+| `getBeachEvents` | `GetEventList` | `referees:events:beach` | 120 s |
+| `getRefereePortraitUrl` | `GetImageList` | `referees:portrait:<id>` | 120 s |
+| `getRefereeIdCardUrl` | `GetRefereeIdCard` | **non cachato** — il token è monouso |
+
+### L'envelope `<Requests>`, di nuovo
+
+`GetRefereeList`, `GetReferee`, `GetImageList` e `GetRefereeIdCard` si comportano
+come `GetEventRefereeList` (#40): **senza** l'envelope `<Requests>` rispondono
+`<NotInNewFormat id="1008" />`. I builder in `VisApiClient` lo mettono; non
+riscriverli "per uniformità" con gli altri endpoint, che invece lo vogliono nudo.
+
+### Il risparmio, misurato
+
+`tournament-ref` chiedeva **tre volte** lo stesso `GetEventRefereeList` in un
+singolo caricamento, più la match list: 4 richieste per montaggio, 8 per
+aprire → indietro → riaprire. Ora sono **2 e 2**. Congelato da
+`__tests__/services/RefereeDirectoryService.test.ts` (blocco "API call budget").
+
+### Due difetti preesistenti, deliberatamente non corretti
+
+- **`ref-mode` si cancella i dati da sola.** Il caricamento finisce con una
+  `GetEvent` che *sovrascrive* incondizionatamente le liste ottenute dagli
+  endpoint dedicati, cercando `<EventOfficialList>` / `<EventRefereeList>` che
+  `GetEvent` non restituisce. Risultato: `Officials (0) / Referees (0)`. È il
+  motivo per cui la schermata è "under construction". Preservato alla lettera
+  con un commento in `app/ref-mode.tsx` che lo marca; toglierlo è una modifica
+  funzionale e vuole la sua issue.
+- **`all-referees` fa fan-out illimitato.** `Promise.all` su una richiesta
+  statistiche **per ogni arbitro attivo**, senza limite di concorrenza →
+  issue #65.
+
 ---
-*Last Updated: 2026-07-25T12:00:00Z*
+*Last Updated: 2026-07-26T12:00:00Z*
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -415,6 +415,30 @@ singolo caricamento, più la match list: 4 richieste per montaggio, 8 per
 aprire → indietro → riaprire. Ora sono **2 e 2**. Congelato da
 `__tests__/services/RefereeDirectoryService.test.ts` (blocco "API call budget").
 
+### Niente header custom, o ogni richiesta costa il doppio
+
+La config del client in questo servizio ha `headers: {}` **di proposito**. Una
+POST con il solo `Content-Type: application/x-www-form-urlencoded` e' una CORS
+*simple request*; basta aggiungere `X-FIVB-App-ID` (come fa `OfficialsService`)
+per renderla non-simple, e il browser antepone una `OPTIONS` di preflight. La
+VIS risponde **senza `Access-Control-Max-Age`**, quindi il preflight non viene
+cachato: **ogni richiesta diventa due round trip**. Misurato sul deploy preview
+della #46: un caricamento di `all-referees` con l'header ha prodotto **31
+`OPTIONS` e zero POST completate**. Non rimetterlo "per uniformita'".
+
+### Limite noto — NON re-indagare
+
+`GetReferee` e `GetImageList` **non funzionano con questo app id, e non
+funzionavano nemmeno prima**. Verificato con richieste dirette alla VIS
+(issue #46): `GetReferee` risponde `<Responses><AccessDenied /></Responses>` sia
+**con** sia **senza** header `X-FIVB-App-ID`; `GetImageList` risponde una pagina
+ASP.NET `Runtime Error` in entrambi i casi. Conseguenza: il ritratto non si
+risolve mai e `referee-profile` mostra il fallback "View ID Card" — che e'
+esattamente cio' che faceva prima, quando le stesse due chiamate fallivano in
+silenzio dentro il componente. Nessun percorso critico chiama `GetReferee`: il
+roster di `GetEventRefereeList` porta gia' gli stessi campi, ed e' per questo che
+`ref-mode` non fa piu' una `GetReferee` per arbitro.
+
 ### Due difetti preesistenti, deliberatamente non corretti
 
 - **`ref-mode` si cancella i dati da sola.** Il caricamento finisce con una

--- a/__tests__/services/RefereeDirectoryService.test.ts
+++ b/__tests__/services/RefereeDirectoryService.test.ts
@@ -1,0 +1,414 @@
+/**
+ * RefereeDirectoryService — issue #46.
+ *
+ * Fixtures only, no network: both collaborators are injected, as
+ * {@link RefereeDirectoryService.setDependencies} exists for. The cache double
+ * is a real in-memory map rather than a `jest.fn()`, so the "a remount inside
+ * the TTL issues no request" property (AC4) and the call budget (AC5) are
+ * measured, not asserted by construction.
+ */
+
+import {
+  RefereeDirectoryService,
+  type RefereeDirectoryApiClient,
+  type RefereeDirectoryCache
+} from '../../services/RefereeDirectoryService';
+import type { VisApiResponse } from '../../types/api-v2';
+
+// ---------------------------------------------------------------------------
+// Fixtures — trimmed from real VIS responses
+// ---------------------------------------------------------------------------
+
+const EVENT_REFEREE_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <EventReferees>
+    <EventReferee No="8811" NoReferee="123456" FirstName="Anna" LastName="Rossi" FederationCode="ITA" Gender="1" Level="International" Role="1" Status="Active" Type="Referee" />
+    <EventReferee No="8812" NoReferee="654321" FirstName="Bob" LastName="Smith" FederationCode="USA" Gender="0" Level="International" Role="2" Status="Active" Type="Referee" />
+    <EventReferee No="8813" NoReferee="" FirstName="" LastName="" FederationCode="" Gender="" />
+  </EventReferees>
+</Responses>`;
+
+const REFEREE_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <Referees>
+    <Referee NoReferee="123456" FirstName="Anna" LastName="Rossi" FederationCode="ITA" Gender="1" Level="International" Status="Active" />
+    <Referee NoReferee="99" FirstName="Short" LastName="Id" FederationCode="FRA" Gender="0" Level="National" Status="Active" />
+    <Referee NoReferee="777777" FirstName="  " LastName="" FederationCode="GER" Gender="0" Level="" Status="Active" />
+  </Referees>
+</Responses>`;
+
+const REFEREE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <Referee NoReferee="123456" FirstName="Anna" LastName="Rossi" FederationCode="ITA" Gender="1" Status="Active" Type="Referee" NoPortraitPhoto="4242" StrongPoints="Positioning" WeakPoints="" TheoryTest="92" Conclusion="Promote" Signatures="2" />
+</Responses>`;
+
+const EVENT_OFFICIAL_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <EventOfficials>
+    <EventOfficial NoOfficial="5001" FirstName="Carla" LastName="Bianchi" FederationCode="ITA" Gender="1" Role="Technical Delegate" Status="Active" Type="Official" NoPortraitPhoto="" Signatures="" />
+  </EventOfficials>
+</Responses>`;
+
+const BEACH_MATCH_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <BeachMatches>
+    <BeachMatch No="1" NoEvent="1053" Status="Finished" NoReferee1="123456" NoReferee2="654321" Referee1Name="Anna Rossi" Referee2Name="Bob Smith" RefereeChallengeName="Carla Bianchi" />
+    <BeachMatch No="2" NoEvent="1053" Status="Scheduled" NoReferee1="654321" NoReferee2="" Referee1Name="Bob Smith" Referee2Name="TBD" />
+  </BeachMatches>
+</Responses>`;
+
+const EVENT_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Responses>
+  <Events>
+    <Event No="1053" Name="Rome Open" StartDate="2026-06-01" />
+    <Event No="1099" Name="Vienna Major" StartDate="2026-08-14" />
+    <Event No="900" Name="Old Cup" StartDate="2019-05-02" />
+    <Event No="901" Name="No Date Cup" />
+  </Events>
+</Responses>`;
+
+const IMAGE_LIST_XML = `<Responses><Images><Image No="778899" /></Images></Responses>`;
+
+const ID_CARD_XML = `<Responses><RefereeIdCard Token="abc-123-token" /></Responses>`;
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+const ok = (xmlData: string): VisApiResponse => ({
+  success: true,
+  xmlData,
+  timestamp: new Date().toISOString(),
+  durationMs: 1,
+  sizeBytes: xmlData.length
+} as VisApiResponse);
+
+const fail = (error = 'boom'): VisApiResponse => ({
+  success: false,
+  error,
+  errorCode: 'VIS_ERROR',
+  timestamp: new Date().toISOString(),
+  durationMs: 1
+} as VisApiResponse);
+
+/** In-memory cache with the same contract as CacheService's subset. */
+class FakeCache implements RefereeDirectoryCache {
+  private store = new Map<string, any>();
+
+  async get<T>(key: string): Promise<{ data: T | undefined; isStale: boolean }> {
+    return { data: this.store.get(key) as T | undefined, isStale: false };
+  }
+
+  async set(key: string, value: any): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  /** Everything the cache holds — used to assert on what got stored. */
+  keys(): string[] {
+    return [...this.store.keys()];
+  }
+
+  /** Simulate the TTL elapsing. */
+  expireAll(): void {
+    this.store.clear();
+  }
+}
+
+const makeClient = (overrides: Partial<RefereeDirectoryApiClient> = {}) => {
+  const calls: string[] = [];
+  const record = <T>(name: string, response: T) => {
+    calls.push(name);
+    return Promise.resolve(response);
+  };
+
+  const client: RefereeDirectoryApiClient & { calls: string[] } = {
+    calls,
+    getEvent: () => record('getEvent', ok('<Responses><Event No="1053" /></Responses>')),
+    getEventRefereeList: () => record('getEventRefereeList', ok(EVENT_REFEREE_LIST_XML)),
+    getEventOfficialList: () => record('getEventOfficialList', ok(EVENT_OFFICIAL_LIST_XML)),
+    getBeachMatchList: () => record('getBeachMatchList', ok(BEACH_MATCH_LIST_XML)),
+    getEventList: () => record('getEventList', ok(EVENT_LIST_XML)),
+    getRefereeList: () => record('getRefereeList', ok(REFEREE_LIST_XML)),
+    getReferee: () => record('getReferee', ok(REFEREE_XML)),
+    getImageList: () => record('getImageList', ok(IMAGE_LIST_XML)),
+    getRefereeIdCard: () => record('getRefereeIdCard', ok(ID_CARD_XML)),
+    ...overrides
+  } as RefereeDirectoryApiClient & { calls: string[] };
+
+  return client;
+};
+
+describe('RefereeDirectoryService', () => {
+  let cache: FakeCache;
+  let client: ReturnType<typeof makeClient>;
+
+  const install = (c: ReturnType<typeof makeClient> = makeClient()) => {
+    client = c;
+    cache = new FakeCache();
+    RefereeDirectoryService.setDependencies({ client, cache });
+    RefereeDirectoryService.resetCallCount();
+  };
+
+  beforeEach(() => install());
+
+  afterAll(() => RefereeDirectoryService.setDependencies(null));
+
+  // -------------------------------------------------------------------------
+  // Parsing
+  // -------------------------------------------------------------------------
+
+  describe('parsing', () => {
+    it('reads the event referee roster and drops nameless rows', async () => {
+      const { referees, error } = await RefereeDirectoryService.getEventReferees('1053');
+
+      expect(error).toBeUndefined();
+      expect(referees).toHaveLength(2);
+      expect(referees[0]).toMatchObject({
+        RefereeId: '123456',
+        eventRefereeNo: '8811',
+        firstName: 'Anna',
+        lastName: 'Rossi',
+        federationCode: 'ITA',
+        level: 'International',
+        role: '1',
+        status: 'Active'
+      });
+    });
+
+    it('normalises the global directory: 6-digit ids only, no nameless rows', async () => {
+      const { referees } = await RefereeDirectoryService.getAllReferees();
+
+      // "Short Id" keeps its name but loses the non-conforming id;
+      // the whitespace-only row is dropped entirely.
+      expect(referees).toHaveLength(2);
+      expect(referees.map(r => r.RefereeId)).toEqual(['123456', '']);
+    });
+
+    it('does not confuse <Referee> with <EventReferee> or <RefereeChallenge>', async () => {
+      const { matches } = await RefereeDirectoryService.getEventMatches('1053');
+      expect(matches).toHaveLength(2);
+      expect(matches[0]!.RefereeChallengeName).toBe('Carla Bianchi');
+
+      // The global directory must not pick up the <EventReferee> rows of a
+      // differently-shaped payload.
+      install(makeClient({ getRefereeList: () => Promise.resolve(ok(EVENT_REFEREE_LIST_XML)) }));
+      const { referees } = await RefereeDirectoryService.getAllReferees();
+      expect(referees).toHaveLength(0);
+    });
+
+    it('reads a single referee record', async () => {
+      const { referee, error } = await RefereeDirectoryService.getReferee('123456');
+
+      expect(error).toBeUndefined();
+      expect(referee).toMatchObject({
+        RefereeId: '123456',
+        firstName: 'Anna',
+        strongPoints: 'Positioning',
+        theoryTest: '92',
+        noPortraitPhoto: '4242'
+      });
+    });
+
+    it('reads event officials', async () => {
+      const { officials } = await RefereeDirectoryService.getEventOfficials('1053');
+
+      expect(officials).toHaveLength(1);
+      expect(officials[0]).toMatchObject({ NoOfficial: '5001', LastName: 'Bianchi', Role: 'Technical Delegate' });
+    });
+
+    it('sorts beach events newest first and drops incomplete rows', async () => {
+      const { events } = await RefereeDirectoryService.getBeachEvents();
+
+      expect(events.map(e => e.visNo)).toEqual(['1099', '1053', '900']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC4 — cache
+  // -------------------------------------------------------------------------
+
+  describe('caching (AC4)', () => {
+    it('serves a second read of the same event from cache — zero extra calls', async () => {
+      await RefereeDirectoryService.getEventReferees('1053');
+      expect(client.calls).toEqual(['getEventRefereeList']);
+
+      await RefereeDirectoryService.getEventReferees('1053');
+      await RefereeDirectoryService.getEventReferees('1053');
+
+      expect(client.calls).toEqual(['getEventRefereeList']);
+      expect(RefereeDirectoryService.getApiCallCount()).toBe(1);
+    });
+
+    it('keys the cache per event — a different event still hits the network', async () => {
+      await RefereeDirectoryService.getEventReferees('1053');
+      await RefereeDirectoryService.getEventReferees('1099');
+
+      expect(client.calls).toEqual(['getEventRefereeList', 'getEventRefereeList']);
+    });
+
+    it('refetches once the entry expires', async () => {
+      await RefereeDirectoryService.getEventReferees('1053');
+      cache.expireAll();
+      await RefereeDirectoryService.getEventReferees('1053');
+
+      expect(client.calls).toHaveLength(2);
+    });
+
+    it('never caches a failure — the next call retries', async () => {
+      let attempt = 0;
+      install(makeClient({
+        getEventRefereeList: () => {
+          attempt += 1;
+          return Promise.resolve(attempt === 1 ? fail('temporary') : ok(EVENT_REFEREE_LIST_XML));
+        }
+      }));
+
+      const first = await RefereeDirectoryService.getEventReferees('1053');
+      expect(first.error).toContain('GetEventRefereeList failed');
+      expect(first.referees).toEqual([]);
+      expect(cache.keys()).toHaveLength(0);
+
+      const second = await RefereeDirectoryService.getEventReferees('1053');
+      expect(second.error).toBeUndefined();
+      expect(second.referees).toHaveLength(2);
+    });
+
+    it('invalidateEvent drops every entry of that event', async () => {
+      await RefereeDirectoryService.getEventReferees('1053');
+      await RefereeDirectoryService.getEventOfficials('1053');
+      await RefereeDirectoryService.getEventMatches('1053');
+      expect(cache.keys()).toHaveLength(3);
+
+      await RefereeDirectoryService.invalidateEvent('1053');
+      expect(cache.keys()).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC5 — call budget for the real navigation scenarios
+  // -------------------------------------------------------------------------
+
+  describe('API call budget (AC5)', () => {
+    /**
+     * `app/tournament-ref.tsx` asks for the event roster three times in a
+     * single load (`loadRefereesFromAPI`, the id→name map, and
+     * `fetchAllRefereesFromAPI`) plus the match list once. Before #46 that was
+     * 4 requests per mount and 8 for open → back → reopen.
+     */
+    const tournamentRefLoad = async (eventNo: string) => {
+      await RefereeDirectoryService.getEventReferees(eventNo);
+      await RefereeDirectoryService.getEventMatches(eventNo);
+      await RefereeDirectoryService.getEventReferees(eventNo);
+      await RefereeDirectoryService.getEventReferees(eventNo);
+    };
+
+    it('collapses one tournament-ref load from 4 requests to 2', async () => {
+      await tournamentRefLoad('1053');
+
+      expect(client.calls).toEqual(['getEventRefereeList', 'getBeachMatchList']);
+      expect(RefereeDirectoryService.getApiCallCount()).toBe(2);
+    });
+
+    it('open → back → reopen costs 2 requests instead of 8', async () => {
+      await tournamentRefLoad('1053'); // open
+      await tournamentRefLoad('1053'); // reopen after going back
+
+      expect(RefereeDirectoryService.getApiCallCount()).toBe(2);
+    });
+
+    /**
+     * `app/all-referees.tsx` walks the event list, then up to 10 events, then
+     * asks for the whole directory twice (active pass + background inactive
+     * pass). The second directory read is what the cache removes here.
+     */
+    it('all-referees downloads the global directory once, not twice', async () => {
+      await RefereeDirectoryService.getBeachEvents();
+      await RefereeDirectoryService.getAllReferees(); // active pass
+      await RefereeDirectoryService.getAllReferees(); // background inactive pass
+
+      expect(client.calls.filter(c => c === 'getRefereeList')).toHaveLength(1);
+    });
+
+    it('ref-mode load costs 3 requests, and 0 on reopen', async () => {
+      const refModeLoad = async () => {
+        await RefereeDirectoryService.getEventReferees('1053');
+        await RefereeDirectoryService.getEventOfficials('1053');
+        await RefereeDirectoryService.getEventRosterFromEvent('1053');
+      };
+
+      await refModeLoad();
+      const afterFirst = RefereeDirectoryService.getApiCallCount();
+      expect(afterFirst).toBe(3);
+
+      await refModeLoad();
+      // getEventRosterFromEvent is deliberately uncached (it is the preserved
+      // legacy fallback), so only it repeats.
+      expect(RefereeDirectoryService.getApiCallCount() - afterFirst).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Media
+  // -------------------------------------------------------------------------
+
+  describe('portrait and ID card', () => {
+    it('resolves and caches a portrait URL', async () => {
+      const url = await RefereeDirectoryService.getRefereePortraitUrl('123456');
+      expect(url).toBe('https://www.fivb.org/Vis2009/Images/GetImage.asmx?No=778899&MaxSize=300');
+
+      await RefereeDirectoryService.getRefereePortraitUrl('123456');
+      expect(client.calls.filter(c => c === 'getImageList')).toHaveLength(1);
+    });
+
+    it('returns null rather than throwing when there is no portrait', async () => {
+      install(makeClient({ getImageList: () => Promise.resolve(ok('<Responses><Images /></Responses>')) }));
+
+      await expect(RefereeDirectoryService.getRefereePortraitUrl('123456')).resolves.toBeNull();
+    });
+
+    it('falls back from Volley to Beach for the ID card', async () => {
+      install(makeClient({
+        getRefereeIdCard: (request) =>
+          Promise.resolve(request.volleyType === 'Volley' ? ok('<Responses />') : ok(ID_CARD_XML))
+      }));
+
+      const url = await RefereeDirectoryService.getRefereeIdCardUrl('123456');
+      expect(url).toBe('https://www.fivb.org/Vis2009/Documents/GetDocument.asmx?Token=abc-123-token');
+    });
+
+    it('does not cache the ID card token — it is one-shot', async () => {
+      await RefereeDirectoryService.getRefereeIdCardUrl('123456');
+      await RefereeDirectoryService.getRefereeIdCardUrl('123456');
+
+      expect(client.calls.filter(c => c === 'getRefereeIdCard')).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error policy
+  // -------------------------------------------------------------------------
+
+  describe('error policy', () => {
+    it('never throws when the client rejects', async () => {
+      install(makeClient({
+        getEventRefereeList: () => Promise.reject(new Error('socket hang up'))
+      }));
+
+      const { referees, error } = await RefereeDirectoryService.getEventReferees('1053');
+      expect(referees).toEqual([]);
+      expect(error).toContain('socket hang up');
+    });
+
+    it('reports a failed GetRefereeList as an empty directory plus an error', async () => {
+      install(makeClient({ getRefereeList: () => Promise.resolve(fail('rate limited')) }));
+
+      const { referees, error } = await RefereeDirectoryService.getAllReferees();
+      expect(referees).toEqual([]);
+      expect(error).toContain('rate limited');
+    });
+  });
+});

--- a/__tests__/services/api/VisApiClient.referee-endpoints.test.ts
+++ b/__tests__/services/api/VisApiClient.referee-endpoints.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview VisApiClient — the referee-directory endpoints added by issue #46.
+ *
+ * These four endpoints used to be spelled out as raw `fetch` calls inside
+ * `app/` screens. What matters here is that the client now produces the *same*
+ * requests the screens produced by hand — in particular the `<Requests>`
+ * envelope, which these endpoints require: sent bare they answer
+ * `<NotInNewFormat id="1008" />` (issue #40).
+ *
+ * `fetch` is mocked; no network.
+ */
+
+import { VisApiClient } from '../../../services/api/VisApiClient';
+import { VisApiClientConfig } from '../../../types/api-v2';
+
+global.fetch = jest.fn();
+
+describe('VisApiClient — referee directory endpoints (issue #46)', () => {
+  let client: VisApiClient;
+  let mockFetch: jest.MockedFunction<typeof fetch>;
+
+  const testConfig: VisApiClientConfig = {
+    baseUrl: 'https://test.fivb.org/Vis2009/XmlRequest.asmx',
+    timeoutMs: 1000,
+    maxRetries: 1,
+    retryDelayMs: 0,
+    exponentialBackoff: false,
+    headers: {},
+    enableLogging: false
+  };
+
+  const testRetryConfig = {
+    maxAttempts: 1,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    exponentialBackoff: false,
+    jitterFactor: 0,
+    retryableStatusCodes: []
+  };
+
+  /** The decoded `Request=` form parameter of the last call. */
+  const lastRequestXml = (): string => {
+    const body = String(mockFetch.mock.calls[mockFetch.mock.calls.length - 1]![1]!.body);
+    return decodeURIComponent(body.replace(/^Request=/, ''));
+  };
+
+  beforeEach(() => {
+    mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '<Responses />'
+    } as Response);
+
+    client = new VisApiClient(testConfig, testRetryConfig);
+  });
+
+  it('posts GetRefereeList inside a <Requests> envelope, filtered by sport', async () => {
+    const response = await client.getRefereeList({ sport: 'BV', fields: ['NoReferee', 'FirstName'] });
+
+    expect(response.success).toBe(true);
+    const xml = lastRequestXml();
+    expect(xml).toBe(
+      '<Requests><Request Type="GetRefereeList" Fields="NoReferee FirstName"><Filter Sport="BV" /></Request></Requests>'
+    );
+  });
+
+  it('omits the filter when no sport is given, and falls back to the default fields', async () => {
+    await client.getRefereeList();
+
+    const xml = lastRequestXml();
+    expect(xml).toContain('<Requests><Request Type="GetRefereeList"');
+    expect(xml).not.toContain('<Filter');
+    expect(xml).toContain('NoReferee FirstName LastName');
+  });
+
+  it('posts GetReferee with the VISId the screens used', async () => {
+    await client.getReferee({ refereeNo: '123456' });
+
+    expect(lastRequestXml()).toBe(
+      '<Requests><Request Type="GetReferee" No="123456" VISId="VIS" /></Requests>'
+    );
+  });
+
+  it('posts GetImageList with the portrait DataType/ImageType pair', async () => {
+    await client.getImageList({ dataType: '61', dataNo: '123456', imageType: '15' });
+
+    expect(lastRequestXml()).toBe(
+      '<Requests><Request Type="GetImageList" Fields="No">' +
+      '<Filter DataType="61" DataNo="123456" ImageType="15" />' +
+      '</Request></Requests>'
+    );
+  });
+
+  it('posts GetRefereeIdCard for the requested discipline', async () => {
+    await client.getRefereeIdCard({ refereeNo: '123456', volleyType: 'Beach' });
+
+    expect(lastRequestXml()).toBe(
+      '<Requests><Request Type="GetRefereeIdCard" No="123456" VolleyType="Beach" /></Requests>'
+    );
+  });
+
+  it('goes through the POST form-encoded transport, like every other endpoint', async () => {
+    await client.getRefereeList({ sport: 'BV' });
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe(testConfig.baseUrl);
+    expect(init!.method).toBe('POST');
+    expect((init!.headers as Record<string, string>)['Content-Type'])
+      .toBe('application/x-www-form-urlencoded');
+    expect(String(init!.body)).toMatch(/^Request=/);
+  });
+
+  it('escapes attribute values instead of letting them break the XML', async () => {
+    await client.getReferee({ refereeNo: '12"34&56' });
+
+    const xml = lastRequestXml();
+    expect(xml).not.toContain('No="12"34');
+    expect(xml).toContain('&quot;');
+    expect(xml).toContain('&amp;');
+  });
+
+  it('returns an error response rather than throwing when the transport fails', async () => {
+    mockFetch.mockRejectedValue(new Error('socket hang up'));
+
+    const response = await client.getRefereeList({ sport: 'BV' });
+
+    expect(response.success).toBe(false);
+  });
+});

--- a/app/all-referees.tsx
+++ b/app/all-referees.tsx
@@ -14,6 +14,7 @@ import { Text } from '../components/Typography/Text';
 import { FlagImage } from '../components/FlagImage';
 import { colors, designTokens } from '../theme/tokens';
 import { RefereeStatsService, SeasonStats, CareerStats } from '../services/RefereeStatsService';
+import { RefereeDirectoryService } from '../services/RefereeDirectoryService';
 import { createShadow } from '../theme/shadows';
 // import { AssignmentStatusProvider } from '../hooks/useAssignmentStatus'; // Not needed for All Referees
 
@@ -28,14 +29,6 @@ interface Referee {
 }
 
 type StatsTab = 'Current' | 'Season' | 'Career';
-
-interface TournamentInfo {
-  visNo: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  status: string;
-}
 
 // Exact RefereeCard component from tournament-ref screen
 const RefereeCard = ({
@@ -383,105 +376,21 @@ function AllRefereesScreenContent() {
   };
 
   const getRecentTournaments = async (year: number): Promise<{visNo: string, name: string}[]> => {
-    try {
-      // Get tournaments from current year
-      const xml = `<Requests>
-  <Request Type="GetEventList"
-           Fields="No Name StartDate">
-    <Filter Sport="BV"/>
-  </Request>
-</Requests>`;
+    // Cached by RefereeDirectoryService: the event list is fetched once and
+    // reused by every later mount within the TTL (issue #46).
+    const { events } = await RefereeDirectoryService.getBeachEvents();
 
-      const response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-        method: "POST",
-        headers: {
-          "Accept": "application/xml",
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: new URLSearchParams({ Request: xml })
-      });
-
-      if (response.ok) {
-        const xmlResponse = await response.text();
-        const tournaments: {visNo: string, name: string, startDate: string}[] = [];
-        
-        // Parse tournaments from XML
-        const eventRegex = /<Event[^>]*>/g;
-        const matches = [...xmlResponse.matchAll(eventRegex)];
-        
-        matches.forEach((match) => {
-          const fullMatch = match[0];
-          const no = fullMatch.match(/No="([^"]*)"/)?.[1];
-          const name = fullMatch.match(/Name="([^"]*)"/)?.[1];
-          const startDate = fullMatch.match(/StartDate="([^"]*)"/)?.[1];
-          
-          if (no && name && startDate) {
-            const tournamentYear = new Date(startDate).getFullYear();
-            if (tournamentYear === year) {
-              tournaments.push({
-                visNo: no,
-                name: name,
-                startDate: startDate
-              });
-            }
-          }
-        });
-
-        // Sort by start date (most recent first)
-        tournaments.sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime());
-        
-        return tournaments;
-      }
-      
-      return [];
-    } catch (error) {
-      console.error('Error getting recent tournaments:', error);
-      return [];
-    }
+    return events.filter(event => new Date(event.startDate).getFullYear() === year);
   };
 
   const getRefereeIdsFromTournament = async (tournamentNo: string): Promise<Set<string>> => {
-    try {
-      // Use GetEventRefereeList to get referees for specific tournament
-      const xml = `<Requests>
-  <Request Type="GetEventRefereeList"
-           Fields="NoReferee">
-    <Filter NoEvent="${tournamentNo}"/>
-  </Request>
-</Requests>`;
+    const { referees } = await RefereeDirectoryService.getEventReferees(tournamentNo);
 
-      const response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-        method: "POST",
-        headers: {
-          "Accept": "application/xml",
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: new URLSearchParams({ Request: xml })
-      });
-      
-      if (response.ok) {
-        const xmlResponse = await response.text();
-        const refereeIds = new Set<string>();
-        
-        // Extract referee IDs from tournament
-        const refereeMatches = xmlResponse.match(/<EventReferee[^>]*>/g);
-        if (refereeMatches) {
-          refereeMatches.forEach(match => {
-            const noReferee = match.match(/NoReferee="([^"]*)"/)?.[1] || '';
-            if (noReferee && /^\d{6}$/.test(noReferee)) {
-              refereeIds.add(noReferee);
-            }
-          });
-        }
-        
-        return refereeIds;
-      }
-      
-      return new Set();
-    } catch (error) {
-      console.error(`Error getting referee IDs from tournament ${tournamentNo}:`, error);
-      return new Set();
-    }
+    return new Set(
+      referees
+        .map(referee => referee.RefereeId)
+        .filter(id => /^\d{6}$/.test(id))
+    );
   };
 
   const getRefereeDetailsByIds = async (refereeIds: string[]): Promise<Referee[]> => {
@@ -521,36 +430,26 @@ function AllRefereesScreenContent() {
     }
   };
 
+  /**
+   * The full beach referee directory.
+   *
+   * This screen asks for it twice per load — once to resolve the active
+   * referees, once again in the background pass for the inactive ones. Both
+   * calls now share one cached entry instead of two full `GetRefereeList`
+   * downloads (issue #46). The 6-digit normalisation and the nameless-row
+   * filter moved into the service alongside the request.
+   */
   const getAllReferees = async (): Promise<Referee[]> => {
-    const xml = `<Requests>
-  <Request Type="GetRefereeList"
-           Fields="NoReferee FirstName LastName FederationCode Gender Level Status Sport">
-    <Filter Sport="BV"/>
-  </Request>
-</Requests>`;
+    const { referees } = await RefereeDirectoryService.getAllReferees();
 
-    const response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-      method: "POST",
-      headers: {
-        "Accept": "application/xml",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: new URLSearchParams({ Request: xml })
-    });
-    
-    if (response.ok) {
-      const xmlResponse = await response.text();
-      const parsedReferees = parseRefereeXML(xmlResponse);
-      
-      const normalized = parsedReferees.map(r => ({
-        ...r,
-        RefereeId: /^\d{6}$/.test(r.RefereeId || '') ? (r.RefereeId as string) : ''
-      })).filter(r => r.firstName?.trim() || r.lastName?.trim());
-      
-      return normalized;
-    }
-    
-    return [];
+    return referees.map(referee => ({
+      RefereeId: referee.RefereeId,
+      firstName: referee.firstName,
+      lastName: referee.lastName,
+      federationCode: referee.federationCode,
+      gender: referee.gender,
+      level: referee.level ?? ''
+    }));
   };
 
   const loadInactiveRefereesBatch = async (inactiveReferees: (Referee & { totalMatches: number; isActive: boolean })[]) => {
@@ -584,38 +483,6 @@ function AllRefereesScreenContent() {
     // This function is a placeholder - actual loading happens in loadActiveSeasonReferees
   };
 
-
-  // Exact same parsing function as tournament-ref screen
-  const parseRefereeXML = (xmlString: string): Referee[] => {
-    const referees: Referee[] = [];
-    // For GetRefereeList, use <Referee> elements, not <EventReferee>
-    const refereeMatches = xmlString.match(/<Referee[^>]*>/g);
-    
-    if (refereeMatches) {
-      refereeMatches.forEach(match => {
-        const noReferee = match.match(/NoReferee="([^"]*)"/)?.[1] || match.match(/No="([^"]*)"/)?.[1] || '';
-        const firstName = match.match(/FirstName="([^"]*)"/)?.[1] || '';
-        const lastName = match.match(/LastName="([^"]*)"/)?.[1] || '';
-        const federationCode = match.match(/FederationCode="([^"]*)"/)?.[1] || '';
-        const gender = match.match(/Gender="([^"]*)"/)?.[1] || '';
-        const level = match.match(/Level="([^"]*)"/)?.[1] || '';
-        
-        // Only add referee if they have at least a name (same logic as tournament-ref)
-        if (firstName.trim() || lastName.trim()) {
-          referees.push({
-            RefereeId: noReferee,
-            firstName,
-            lastName,
-            federationCode,
-            gender,
-            level
-          });
-        }
-      });
-    }
-    
-    return referees;
-  };
 
   // Filter referees based on search query
   const filteredReferees = React.useMemo(() => {

--- a/app/ref-mode.tsx
+++ b/app/ref-mode.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -12,6 +12,10 @@ import { NavigationHeader } from '../components/navigation/NavigationHeader';
 import { BottomTabNavigation } from '../components/navigation/BottomTabNavigation';
 import { AssignmentStatusProvider } from '../hooks/useAssignmentStatus';
 import { designTokens } from '../theme/tokens';
+import {
+  RefereeDirectoryService,
+  type DirectoryReferee
+} from '../services/RefereeDirectoryService';
 
 interface Official {
   FederationCode: string;
@@ -42,6 +46,23 @@ interface Referee {
   WeakPoints: string;
 }
 
+/** Adapt a service referee to the shape this screen renders. */
+const toScreenReferee = (referee: DirectoryReferee): Referee => ({
+  Conclusion: '',
+  FederationCode: referee.federationCode,
+  FirstName: referee.firstName,
+  Gender: referee.gender,
+  LastName: referee.lastName,
+  NoPortraitPhoto: '',
+  NoReferee: referee.RefereeId,
+  Signatures: '',
+  Status: referee.status ?? '',
+  StrongPoints: '',
+  TheoryTest: '',
+  Type: referee.type ?? '',
+  WeakPoints: ''
+});
+
 const RefModeScreen: React.FC = () => {
   const router = useRouter();
   const { eventNo, tournamentName } = useLocalSearchParams<{ 
@@ -59,72 +80,44 @@ const RefModeScreen: React.FC = () => {
     router.back();
   };
 
-  // Extract referees from match assignments as fallback
-  const extractRefereesFromMatches = async (eventNo: string) => {
-    try {
-      
-      // Get match data for the event
-      const { VisApiClient } = await import('../services/api/VisApiClient');
-      const visApi = new VisApiClient();
-      
-      const matchResponse = await visApi.getBeachMatchList({
-        eventNo: eventNo,
-        maxResults: 100
-      });
-      
-      if (matchResponse.success && matchResponse.xmlData) {
-        
-        // Parse match XML to extract referee names
-        const refereeNamesSet = new Set<string>();
-        const xmlData = matchResponse.xmlData;
-        
-        // Extract referee names from match XML
-        const refereePatterns = [
-          /Referee1="([^"]+)"/g,
-          /Referee2="([^"]+)"/g,
-          /Referee="([^"]+)"/g
-        ];
-        
-        refereePatterns.forEach(pattern => {
-          let match;
-          while ((match = pattern.exec(xmlData)) !== null) {
-            const refereeName = (match[1] ?? '').trim();
-            if (refereeName && refereeName !== '' && refereeName !== 'TBD') {
-              refereeNamesSet.add(refereeName);
-            }
-          }
-        });
-        
-        // Convert to referee objects
-        const extractedReferees: Referee[] = Array.from(refereeNamesSet).map((name, index) => {
-          const [firstName, ...lastNameParts] = name.split(' ');
-          return {
-            NoReferee: `EXTRACTED_${index + 1}`,
-            FirstName: firstName || '',
-            LastName: lastNameParts.join(' ') || '',
-            FederationCode: '',
-            Gender: '',
-            NoPortraitPhoto: '',
-            Signatures: '',
-            Status: 'ACTIVE',
-            Conclusion: '',
-            StrongPoints: '',
-            TheoryTest: '',
-            Type: 'EXTRACTED',
-            WeakPoints: ''
-          };
-        });
-        
-        if (extractedReferees.length > 0) {
-          setReferees(extractedReferees);
+  /**
+   * Referees deduced from the match assignments — the fallback used when the
+   * event has no referee roster of its own.
+   */
+  const extractRefereesFromMatches = async (event: string): Promise<Referee[]> => {
+    const { matches } = await RefereeDirectoryService.getEventMatches(event);
+
+    const refereeNames = new Set<string>();
+    for (const match of matches) {
+      for (const key of ['Referee1Name', 'Referee2Name', 'Referee1', 'Referee2', 'Referee']) {
+        const name = (match[key] ?? '').trim();
+        if (name && name !== 'TBD') {
+          refereeNames.add(name);
         }
       }
-    } catch (error) {
-      console.error('❌ Failed to extract referees from matches:', error);
     }
+
+    return Array.from(refereeNames).map((name, index) => {
+      const [firstName, ...lastNameParts] = name.split(' ');
+      return {
+        NoReferee: `EXTRACTED_${index + 1}`,
+        FirstName: firstName || '',
+        LastName: lastNameParts.join(' ') || '',
+        FederationCode: '',
+        Gender: '',
+        NoPortraitPhoto: '',
+        Signatures: '',
+        Status: 'ACTIVE',
+        Conclusion: '',
+        StrongPoints: '',
+        TheoryTest: '',
+        Type: 'EXTRACTED',
+        WeakPoints: ''
+      };
+    });
   };
 
-  const loadOfficialData = async () => {
+  const loadOfficialData = useCallback(async () => {
     if (!eventNo) {
       setError('No event number provided');
       return;
@@ -132,107 +125,47 @@ const RefModeScreen: React.FC = () => {
 
     setLoading(true);
     setError(null);
-    
+
     try {
-      const { VisApiClient } = await import('../services/api/VisApiClient');
-      const { DEFAULT_RETRY_CONFIG } = await import('../types/api-v2');
-      
-      const config = {
-        baseUrl: 'https://www.fivb.org/Vis2009/XmlRequest.asmx',
-        timeoutMs: 30000,
-        maxRetries: 3,
-        retryDelayMs: 1000,
-        enableLogging: true,
-        headers: {}
-      };
-      
-      const visApi = new VisApiClient(config, DEFAULT_RETRY_CONFIG);
+      // Referee roster of the event. RefereeDirectoryService owns the
+      // <Requests> envelope this screen used to spell out by hand — the
+      // workaround now lives in VisApiClient (issue #40).
+      const { referees: eventReferees, error: refereesError } =
+        await RefereeDirectoryService.getEventReferees(eventNo);
 
+      let resolvedReferees: Referee[] = eventReferees.map(toScreenReferee);
 
-      // Make specific GetEventRefereeList request using GET method like the manual
-      
-      // Request specific fields as provided
-      const refereeRequest = `<Requests><Request Type='GetEventRefereeList' Fields='Conclusion FederationCode FirstName Gender LastName NoPortraitPhoto NoReferee Signatures Status StrongPoints TheoryTest Type WeakPoints'><Filter NoEvent='${eventNo}'/></Request></Requests>`;
-      const refereeUrl = `https://www.fivb.org/vis2009/XmlRequest.asmx?Request=${encodeURIComponent(refereeRequest)}`;
-      
-
-      try {
-        const refereeResponse = await fetch(refereeUrl, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/xml, text/xml, */*',
-            'X-FIVB-App-ID': '2a9523517c52420da73d927c6d6bab23'
-          }
-        });
-        
-        if (refereeResponse.ok) {
-          const refereeData = await refereeResponse.text();
-          
-          // Parse referee numbers from the response
-          const refereeNumbers = parseRefereeNumbers(refereeData);
-          
-          // Get detailed info for each referee
-          if (refereeNumbers.length > 0) {
-            const detailedReferees = await getDetailedReferees(refereeNumbers.slice(0, 3)); // Limit to first 3 for testing
-            setReferees(detailedReferees);
-          }
-        } else {
-          console.error('❌ GetEventRefereeList HTTP error:', refereeResponse.status, refereeResponse.statusText);
-          // Try fallback: extract referees from match assignments
-          await extractRefereesFromMatches(eventNo);
-        }
-      } catch (error) {
-        console.error('❌ GetEventRefereeList failed:', error);
-        // Try fallback: extract referees from match assignments
-        await extractRefereesFromMatches(eventNo);
+      // Same fallback as before: no roster ⇒ deduce the names from the matches.
+      if (refereesError || resolvedReferees.length === 0) {
+        resolvedReferees = await extractRefereesFromMatches(eventNo);
       }
 
-      // Also try GetEventOfficialList with GET
-      
-      const officialRequest = `<Requests><Request Type='GetEventOfficialList' Fields='FederationCode FirstName Gender LastName NoPortraitPhoto NoOfficial Role Signatures Status Type'><Filter NoEvent='${eventNo}'/></Request></Requests>`;
-      const officialUrl = `https://www.fivb.org/vis2009/XmlRequest.asmx?Request=${encodeURIComponent(officialRequest)}`;
-      
+      setReferees(resolvedReferees);
 
-      try {
-        const officialResponse = await fetch(officialUrl, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/xml, text/xml, */*',
-            'X-FIVB-App-ID': '2a9523517c52420da73d927c6d6bab23'
-          }
-        });
-        
-        if (officialResponse.ok) {
-          const officialData = await officialResponse.text();
-          
-          const officialsData = parseOfficials(officialData);
-          setOfficials(officialsData);
-        } else {
-          console.error('❌ GetEventOfficialList HTTP error:', officialResponse.status, officialResponse.statusText);
-        }
-      } catch (error) {
-        console.error('❌ GetEventOfficialList failed:', error);
-      }
+      const { officials: eventOfficials } =
+        await RefereeDirectoryService.getEventOfficials(eventNo);
 
-      // Fallback: Try GetEvent with officials and referees enabled
-      const eventResponse = await visApi.getEvent({
-        eventNo: eventNo,
-        includeOfficials: true,
-        includeReferees: true
-      });
+      // GetEventOfficialList exposes only `No` and `Version` for these two
+      // entities (investigated at length in issue #40), so nameless rows are
+      // dropped rather than rendered as blank cards — which is what this screen
+      // showed before, its parser requiring a wrapper the response never has.
+      setOfficials(eventOfficials.filter(o => o.FirstName.trim() || o.LastName.trim()));
 
-      if (eventResponse.success && eventResponse.xmlData) {
-        
-        // Parse officials from the response
-        const officialsData = parseOfficials(eventResponse.xmlData);
-        const refereesData = parseReferees(eventResponse.xmlData);
-        
-        
-        setOfficials(officialsData);
-        setReferees(refereesData);
-      } else {
+      // ⚠️ PRE-EXISTING DEFECT, PRESERVED ON PURPOSE (issue #46 is a refactoring).
+      // This final GetEvent unconditionally *overwrites* both lists with what it
+      // can parse out of the event payload — and it can parse nothing, because
+      // GetEvent does not answer with <EventOfficialList> / <EventRefereeList>.
+      // The net effect is that everything resolved above is discarded and the
+      // screen renders "Officials (0) / Referees (0)". That is why ref-mode is
+      // "under construction" in CLAUDE.md. Removing these four lines makes the
+      // screen work; doing so is a functional change and needs its own issue.
+      const roster = await RefereeDirectoryService.getEventRosterFromEvent(eventNo);
+
+      if (roster.error) {
         setError('Failed to load official data');
-        console.error('❌ Failed to get event data:', eventResponse.error);
+      } else {
+        setOfficials(roster.officials);
+        setReferees(roster.referees.map(toScreenReferee));
       }
     } catch (error) {
       console.error('❌ Error loading official data:', error);
@@ -240,176 +173,7 @@ const RefModeScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
-
-  // Function to parse referee numbers from GetEventRefereeList response
-  const parseRefereeNumbers = (xmlData: string): string[] => {
-    try {
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
-      const refereeElements = xmlDoc.getElementsByTagName('EventReferee');
-      
-      const numbers = [];
-      for (let i = 0; i < refereeElements.length; i++) {
-        const no = refereeElements[i]!.getAttribute('No');
-        if (no) {
-          numbers.push(no);
-        }
-      }
-      return numbers;
-    } catch (error) {
-      console.error('Error parsing referee numbers:', error);
-      return [];
-    }
-  };
-
-  // Function to get detailed referee information
-  const getDetailedReferees = async (refereeNumbers: string[]): Promise<Referee[]> => {
-    const detailedReferees: Referee[] = [];
-    
-    for (const refereeNo of refereeNumbers) {
-      try {
-        
-        const refereeRequest = `<Requests><Request Type='GetReferee' No='${refereeNo}' VISId='VIS'/></Requests>`;
-        const refereeUrl = `https://www.fivb.org/vis2009/XmlRequest.asmx?Request=${encodeURIComponent(refereeRequest)}`;
-        
-        
-        const response = await fetch(refereeUrl, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/xml, text/xml, */*',
-            'X-FIVB-App-ID': '2a9523517c52420da73d927c6d6bab23'
-          }
-        });
-        
-        if (response.ok) {
-          const refereeData = await response.text();
-          
-          // Parse individual referee data
-          const parsedReferee = parseIndividualReferee(refereeData, refereeNo);
-          if (parsedReferee) {
-            detailedReferees.push(parsedReferee);
-          }
-        } else {
-          console.error(`❌ GetReferee failed for ${refereeNo}:`, response.status, response.statusText);
-        }
-      } catch (error) {
-        console.error(`❌ Error getting referee ${refereeNo}:`, error);
-      }
-    }
-    
-    return detailedReferees;
-  };
-
-  // Function to parse individual referee data
-  const parseIndividualReferee = (xmlData: string, refereeNo: string): Referee | null => {
-    try {
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(xmlData, 'text/xml');
-      const refereeElements = xmlDoc.getElementsByTagName('Referee');
-      
-      if (refereeElements.length > 0) {
-        const referee = refereeElements[0]!;
-
-        return {
-          Conclusion: referee.getAttribute('Conclusion') || '',
-          FederationCode: referee.getAttribute('FederationCode') || '',
-          FirstName: referee.getAttribute('FirstName') || '',
-          Gender: referee.getAttribute('Gender') || '',
-          LastName: referee.getAttribute('LastName') || '',
-          NoPortraitPhoto: referee.getAttribute('NoPortraitPhoto') || '',
-          NoReferee: referee.getAttribute('NoReferee') || refereeNo,
-          Signatures: referee.getAttribute('Signatures') || '',
-          Status: referee.getAttribute('Status') || '',
-          StrongPoints: referee.getAttribute('StrongPoints') || '',
-          TheoryTest: referee.getAttribute('TheoryTest') || '',
-          Type: referee.getAttribute('Type') || '',
-          WeakPoints: referee.getAttribute('WeakPoints') || '',
-        };
-      }
-      return null;
-    } catch (error) {
-      console.error('Error parsing individual referee:', error);
-      return null;
-    }
-  };
-
-  const parseOfficials = (xmlData: string): Official[] => {
-    try {
-      // Look for EventOfficialList in the XML response
-      const officialListMatch = xmlData.match(/<EventOfficialList[^>]*>(.*?)<\/EventOfficialList>/s);
-      if (!officialListMatch) {
-        return [];
-      }
-
-      const officialListXml = officialListMatch[1]!;
-      const officialMatches = officialListXml.match(/<EventOfficial[^>]*\/>/g) || [];
-      
-      return officialMatches.map(match => {
-        const parseAttribute = (attr: string) => {
-          const regex = new RegExp(`${attr}="([^"]*)"`, 'i');
-          const result = match.match(regex);
-          return result ? result[1] : '';
-        };
-
-        return {
-          FederationCode: parseAttribute('FederationCode'),
-          FirstName: parseAttribute('FirstName'),
-          Gender: parseAttribute('Gender'),
-          LastName: parseAttribute('LastName'),
-          NoPortraitPhoto: parseAttribute('NoPortraitPhoto'),
-          NoOfficial: parseAttribute('NoOfficial'),
-          Role: parseAttribute('Role'),
-          Signatures: parseAttribute('Signatures'),
-          Status: parseAttribute('Status'),
-          Type: parseAttribute('Type'),
-        };
-      });
-    } catch (error) {
-      console.error('Error parsing officials:', error);
-      return [];
-    }
-  };
-
-  const parseReferees = (xmlData: string): Referee[] => {
-    try {
-      // Look for EventRefereeList in the XML response
-      const refereeListMatch = xmlData.match(/<EventRefereeList[^>]*>(.*?)<\/EventRefereeList>/s);
-      if (!refereeListMatch) {
-        return [];
-      }
-
-      const refereeListXml = refereeListMatch[1]!;
-      const refereeMatches = refereeListXml.match(/<EventReferee[^>]*\/>/g) || [];
-      
-      return refereeMatches.map(match => {
-        const parseAttribute = (attr: string) => {
-          const regex = new RegExp(`${attr}="([^"]*)"`, 'i');
-          const result = match.match(regex);
-          return result ? result[1] : '';
-        };
-
-        return {
-          Conclusion: parseAttribute('Conclusion'),
-          FederationCode: parseAttribute('FederationCode'),
-          FirstName: parseAttribute('FirstName'),
-          Gender: parseAttribute('Gender'),
-          LastName: parseAttribute('LastName'),
-          NoPortraitPhoto: parseAttribute('NoPortraitPhoto'),
-          NoReferee: parseAttribute('NoReferee'),
-          Signatures: parseAttribute('Signatures'),
-          Status: parseAttribute('Status'),
-          StrongPoints: parseAttribute('StrongPoints'),
-          TheoryTest: parseAttribute('TheoryTest'),
-          Type: parseAttribute('Type'),
-          WeakPoints: parseAttribute('WeakPoints'),
-        };
-      });
-    } catch (error) {
-      console.error('Error parsing referees:', error);
-      return [];
-    }
-  };
+  }, [eventNo]);
 
   useEffect(() => {
     if (eventNo) {

--- a/app/referee-profile.tsx
+++ b/app/referee-profile.tsx
@@ -19,6 +19,14 @@ import { RefereeAnalyticsDashboard } from '../components/RefereeAnalytics/Refere
 import { useRefereeAnalytics } from '../hooks/useRefereeAnalytics';
 import { colors, designTokens } from '../theme/tokens';
 import { ActionIcons } from '../components/Icons/IconLibrary';
+import { RefereeDirectoryService } from '../services/RefereeDirectoryService';
+
+/**
+ * The VIS identifier of a referee, whichever of the three shapes the caller
+ * navigated with carries it.
+ */
+const refereeVisId = (referee: EventReferee | RefereeOfficial): string =>
+  String((referee as any).id || (referee as any).RefereeId || (referee as any).noOfficial || '');
 
 /**
  * Individual Referee Profile Dashboard Screen
@@ -49,36 +57,27 @@ const RefereeProfileScreen: React.FC = () => {
     }
   }, [refereeData, router]);
 
-  // Try to fetch portrait image URL via VIS Images API
+  // Portrait image URL, resolved by RefereeDirectoryService (issue #46).
+  // The portrait is optional: a failure leaves the ID-card button in place.
   useEffect(() => {
-    const fetchPortrait = async () => {
-      try {
-        if (!referee) return;
-        const id = (referee as any).id || (referee as any).RefereeId || (referee as any).noOfficial;
-        if (!id) return;
-        const appId = '2a9523517c52420da73d927c6d6bab23';
-        const xml = `<Requests><Request Type="GetImageList" Fields="No"><Filter DataType="61" DataNo="${id}" ImageType="15"/></Request></Requests>`;
-        const resp = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'X-FIVB-App-ID': appId,
-            'Accept': 'application/xml'
-          },
-          body: new URLSearchParams({ Request: xml }) as any
-        });
-        if (!resp.ok) return;
-        const txt = await resp.text();
-        const m = txt.match(/<Image[^>]*\sNo="(\d+)"/);
-        if (m && m[1]) {
-          const url = `https://www.fivb.org/Vis2009/Images/GetImage.asmx?No=${m[1]}&MaxSize=300`;
-          setPortraitUrl(url);
-        }
-      } catch {
-        // Swallow errors; portrait is optional
+    let cancelled = false;
+
+    const loadPortrait = async () => {
+      if (!referee) return;
+      const id = refereeVisId(referee);
+      if (!id) return;
+
+      const url = await RefereeDirectoryService.getRefereePortraitUrl(id);
+      if (!cancelled && url) {
+        setPortraitUrl(url);
       }
     };
-    fetchPortrait();
+
+    loadPortrait();
+
+    return () => {
+      cancelled = true;
+    };
   }, [referee]);
 
   // Get referee analytics
@@ -112,6 +111,17 @@ const RefereeProfileScreen: React.FC = () => {
 
   const handleBack = () => {
     router.back();
+  };
+
+  const handleOpenIdCard = async () => {
+    if (!referee) return;
+    const id = refereeVisId(referee);
+    if (!id) return;
+
+    const url = await RefereeDirectoryService.getRefereeIdCardUrl(id);
+    if (url) {
+      await Linking.openURL(url);
+    }
   };
 
   if (loading || !referee) {
@@ -201,31 +211,7 @@ const RefereeProfileScreen: React.FC = () => {
           ) : (
             <TouchableOpacity
               style={styles.idCardButton}
-              onPress={async () => {
-                try {
-                  const id = (referee as any).id || (referee as any).RefereeId || (referee as any).noOfficial;
-                  if (!id) return;
-                  const appId = '2a9523517c52420da73d927c6d6bab23';
-                  // Try Volley first, then Beach
-                  const tryTypes = ['Volley', 'Beach'];
-                  for (const vt of tryTypes) {
-                    const xml = `<Requests><Request Type="GetRefereeIdCard" No="${id}" VolleyType="${vt}"/></Requests>`;
-                    const resp = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-FIVB-App-ID': appId, 'Accept': 'application/xml' },
-                      body: new URLSearchParams({ Request: xml }) as any
-                    });
-                    if (!resp.ok) continue;
-                    const txt = await resp.text();
-                    const m = txt.match(/Token="([^"]+)"/);
-                    if (m && m[1]) {
-                      const url = `https://www.fivb.org/Vis2009/Documents/GetDocument.asmx?Token=${m[1]}`;
-                      await Linking.openURL(url);
-                      break;
-                    }
-                  }
-                } catch {}
-              }}
+              onPress={handleOpenIdCard}
             >
               <Text style={styles.idCardButtonText}>View ID Card</Text>
             </TouchableOpacity>

--- a/app/tournament-ref.tsx
+++ b/app/tournament-ref.tsx
@@ -8,6 +8,10 @@ import { colors, designTokens } from '../theme/tokens';
 import { AssignmentStatusProvider } from '../hooks/useAssignmentStatus';
 import { RefereeStatsService, SeasonStats, CareerStats } from '../services/RefereeStatsService';
 import { FlagImage } from '../components/FlagImage';
+import {
+  RefereeDirectoryService,
+  type DirectoryReferee
+} from '../services/RefereeDirectoryService';
 
 interface Referee {
   RefereeId: string; // 6-digit NoReferee from VIS API
@@ -17,6 +21,20 @@ interface Referee {
   gender: string;
   level?: string;
 }
+
+/**
+ * Adapt a service referee to the shape this screen renders, keeping the
+ * normalisation the screen used to apply inline: a `RefereeId` is only kept
+ * when it really is the 6-digit `NoReferee`.
+ */
+const toScreenReferee = (referee: DirectoryReferee): Referee => ({
+  RefereeId: /^\d{6}$/.test(referee.RefereeId) ? referee.RefereeId : '',
+  firstName: referee.firstName,
+  lastName: referee.lastName,
+  federationCode: referee.federationCode,
+  gender: referee.gender,
+  level: referee.level ?? ''
+});
 
 interface RefereeStats {
   totalMatches: number;
@@ -302,168 +320,41 @@ function TournamentRefScreenContent() {
     }
   };
 
+  /**
+   * Event referee roster (issue #46).
+   *
+   * This screen used to request the same `GetEventRefereeList` from three
+   * different places in a single load. All three now go through
+   * RefereeDirectoryService and share one cached entry.
+   */
   const loadRefereesFromAPI = async (): Promise<boolean> => {
-    try {
-      const xml = `<Requests>
-  <Request Type="GetEventRefereeList"
-           Fields="NoReferee FirstName LastName FederationCode Gender Role Status">
-    <Filter NoEvent="${tournamentNo}"/>
-  </Request>
-</Requests>`;
+    const { referees: eventReferees } = await RefereeDirectoryService.getEventReferees(tournamentNo);
 
-      const response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-        method: "POST",
-        headers: {
-          "Accept": "application/xml",
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: new URLSearchParams({ Request: xml })
-      });
-      
-      if (response.ok) {
-        const xmlResponse = await response.text();
-        const parsedReferees = parseRefereeXML(xmlResponse);
-        if (parsedReferees.length > 0) {
-          const normalized = parsedReferees.map(r => ({
-            ...r,
-            RefereeId: /^\d{6}$/.test(r.RefereeId || '') ? (r.RefereeId as string) : ''
-          })).filter(r => r.firstName?.trim() || r.lastName?.trim());
-          setReferees(normalized);
-          return normalized.length > 0;
-        }
-      }
-      return false;
-    } catch (error) {
-      console.error('Error in loadRefereesFromAPI:', error);
-      return false;
+    const normalized = eventReferees.map(toScreenReferee);
+    if (normalized.length > 0) {
+      setReferees(normalized);
     }
-  };
 
-  // Helper function to parse XML response into match objects
-  const parseMatchesFromXML = (xmlText: string) => {
-    const matches: any[] = [];
-    
-    try {
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(xmlText, 'text/xml');
-      
-      // Try different possible XML structures
-      const selectors = [
-        'BeachMatch',
-        'Beachvolleyball > BeachMatch',
-        'Response > BeachMatch',
-        'Responses > Response > BeachMatch'
-      ];
-      
-      let matchNodes: NodeListOf<Element> | null = null;
-      for (const selector of selectors) {
-        matchNodes = xmlDoc.querySelectorAll(selector);
-        if (matchNodes.length > 0) {
-          break;
-        }
-      }
-      
-      if (!matchNodes || matchNodes.length === 0) {
-        // Fallback: Use regex to extract BeachMatch elements
-        const matchRegex = /<BeachMatch[^>]*>/g;
-        const regexMatches = [...xmlText.matchAll(matchRegex)];
-        
-        regexMatches.forEach((matchStr) => {
-          const match: any = {};
-          const fullMatch = matchStr[0];
-          
-          // Extract all attributes using regex
-          const attrRegex = /(\w+)="([^"]*)"/g;
-          let attrMatch;
-          while ((attrMatch = attrRegex.exec(fullMatch)) !== null) {
-            match[attrMatch[1]] = attrMatch[2];
-          }
-          
-          matches.push(match);
-        });
-      } else {
-        // Use DOM parsing
-        matchNodes.forEach((matchNode) => {
-          const match: any = {};
-          
-          // Extract all attributes from the match node
-          const attributes = matchNode.attributes;
-          for (let i = 0; i < attributes.length; i++) {
-            const attr = attributes[i];
-            match[attr?.name] = attr.value;
-          }
-          
-          matches.push(match);
-        });
-      }
-      
-    } catch (error) {
-      // Silent fail
-    }
-    
-    return matches;
+    return normalized.length > 0;
   };
 
 
 
+
+  /**
+   * Referee names used to enrich the ones extracted from the match list:
+   * the event roster first, the global directory as a fallback (issue #46).
+   * Both requests are cached, and the first one is the very same entry
+   * {@link loadRefereesFromAPI} already populated.
+   */
   const fetchAllRefereesFromAPI = async (): Promise<Referee[]> => {
-    try {
-      
-      // Try GetEventRefereeList first
-      let xml = `<Requests>
-  <Request Type="GetEventRefereeList"
-           Fields="NoReferee FirstName LastName FederationCode Gender Level Status">
-    <Filter NoEvent="${tournamentNo}"/>
-  </Request>
-</Requests>`;
-
-      let response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-        method: "POST",
-        headers: {
-          "Accept": "application/xml",
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: new URLSearchParams({ Request: xml })
-      });
-
-      if (response.ok) {
-        const xmlResponse = await response.text();
-        const referees = parseRefereeXML(xmlResponse);
-        
-        if (referees.length > 0) {
-          return referees;
-        }
-      }
-      
-      // Fallback: Try GetRefereeList without event filter
-      xml = `<Requests>
-  <Request Type="GetRefereeList"
-           Fields="NoReferee FirstName LastName FederationCode Gender Level Status">
-  </Request>
-</Requests>`;
-
-      response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-        method: "POST",
-        headers: {
-          "Accept": "application/xml",
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: new URLSearchParams({ Request: xml })
-      });
-
-      if (response.ok) {
-        const xmlResponse = await response.text();
-        const referees = parseRefereeListXML(xmlResponse);
-        if (referees.length > 0) {
-          return referees;
-        }
-      }
-      
-      return [];
-    } catch (error) {
-      console.error('Failed to fetch all referees from API:', error);
-      return [];
+    const { referees: eventReferees } = await RefereeDirectoryService.getEventReferees(tournamentNo);
+    if (eventReferees.length > 0) {
+      return eventReferees.map(toScreenReferee);
     }
+
+    const { referees: allReferees } = await RefereeDirectoryService.getAllReferees();
+    return allReferees.map(toScreenReferee);
   };
 
 
@@ -671,47 +562,12 @@ function TournamentRefScreenContent() {
     
     // Fallback to API call if no match data passed or if parsing failed
     try {
-      
-      // Use CacheService first to get matches if available
-      let matches: any[] = [];
-      
-      // Skip CacheService for referee data - it doesn't include NoReferee1/NoReferee2 fields
-      // We need to use direct API call to get referee NoReferee IDs
-      
-      // If CacheService didn't work, make direct API call
-      if (matches.length === 0) {
-        const xml = `<Requests>
-  <Request Type="GetBeachMatchList"
-           Fields="No NoInTournament TournamentGender TeamAName TeamBName LocalDate LocalTime Court Status Round MatchPointsA MatchPointsB PointsTeamASet1 PointsTeamBSet1 PointsTeamASet2 PointsTeamBSet2 PointsTeamASet3 PointsTeamBSet3 NoReferee1 NoReferee2 Referee1Name Referee2Name Referee1FederationCode Referee2FederationCode">
-    <Filter NoEvent="${tournamentNo}" IncludeReferees="true"/>
-  </Request>
-</Requests>`;
+      // Match list of the event, through RefereeDirectoryService (issue #46).
+      // The client's GetBeachMatchList field set is a superset of the one this
+      // screen used to spell out, NoReferee1 / NoReferee2 included, and the
+      // 45 s abort is now the client's own timeout.
+      const { matches } = await RefereeDirectoryService.getEventMatches(tournamentNo);
 
-        
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 45000);
-        
-        const response = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-          method: "POST",
-          headers: {
-            "Accept": "application/xml",
-            "Content-Type": "application/x-www-form-urlencoded"
-          },
-          body: new URLSearchParams({ Request: xml }),
-          signal: controller.signal
-        });
-        
-        clearTimeout(timeoutId);
-        
-        if (!response.ok) {
-          throw new Error(`API request failed: ${response.status}`);
-        }
-        
-        const xmlResponse = await response.text();
-        
-        matches = parseMatchesFromXML(xmlResponse);
-      }
-      
       // Extract referee names using refereeAssignments field (more robust)
       const refereeNames = new Set<string>();
       
@@ -770,52 +626,22 @@ function TournamentRefScreenContent() {
       // Create a reverse mapping: NoReferee ID → Referee name using GetEventRefereeList
       const idToRefereeMap = new Map<string, {firstName: string, lastName: string, federationCode: string, gender: string}>();
       
-      if (true) {
-        try {
-          // Get all referees for this event to build ID-to-name mapping
-          const refereeListXml = `<Requests>
-  <Request Type="GetEventRefereeList"
-           Fields="NoReferee FirstName LastName FederationCode Gender Status Role">
-    <Filter NoEvent="${tournamentNo}"/>
-  </Request>
-</Requests>`;
+      // Third and last read of the same event roster in this load — served from
+      // the cache RefereeDirectoryService populated above (issue #46).
+      const { referees: rosterReferees } = await RefereeDirectoryService.getEventReferees(tournamentNo);
 
-          const refereeResponse = await fetch('https://www.fivb.org/Vis2009/XmlRequest.asmx', {
-            method: "POST",
-            headers: {
-              "Accept": "application/xml",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            body: new URLSearchParams({ Request: refereeListXml })
-          });
-          
-          if (refereeResponse.ok) {
-            const refereeXml = await refereeResponse.text();
-            
-            // Parse referee list to build ID mapping
-            const refereeMatches = refereeXml.match(/<EventReferee[^>]*>/g);
-            if (refereeMatches) {
-              refereeMatches.forEach(match => {
-                const noReferee = match.match(/NoReferee="([^"]*)"/)?.[1] || '';
-                const firstName = match.match(/FirstName="([^"]*)"/)?.[1] || '';
-                const lastName = match.match(/LastName="([^"]*)"/)?.[1] || '';
-                const federationCode = match.match(/FederationCode="([^"]*)"/)?.[1] || '';
-                const gender = match.match(/Gender="([^"]*)"/)?.[1] || '';
-                
-                if (noReferee && /^\d{6}$/.test(noReferee)) {
-                  idToRefereeMap.set(noReferee, { firstName, lastName, federationCode, gender });
-                  const key1 = `${firstName} ${lastName}`.trim().toLowerCase();
-                  const key2 = `${lastName} ${firstName}`.trim().toLowerCase();
-                  if (key1) nameToIdFromAPI.set(key1, noReferee);
-                  if (key2) nameToIdFromAPI.set(key2, noReferee);
-                }
-              });
-            }
-          }
-        } catch (error) {
-          // Silent error handling for referee details fetch
+      rosterReferees.forEach(({ RefereeId, firstName, lastName, federationCode, gender }) => {
+        if (!/^\d{6}$/.test(RefereeId)) {
+          return;
         }
-      }
+
+        idToRefereeMap.set(RefereeId, { firstName, lastName, federationCode, gender });
+
+        const key1 = `${firstName} ${lastName}`.trim().toLowerCase();
+        const key2 = `${lastName} ${firstName}`.trim().toLowerCase();
+        if (key1) nameToIdFromAPI.set(key1, RefereeId);
+        if (key2) nameToIdFromAPI.set(key2, RefereeId);
+      });
       
 
       // Create referees directly from the ID-to-referee mapping
@@ -881,67 +707,6 @@ function TournamentRefScreenContent() {
       setReferees([]);
     }
   };
-
-  const parseRefereeXML = (xmlString: string): Referee[] => {
-    const referees: Referee[] = [];
-    const refereeMatches = xmlString.match(/<EventReferee[^>]*>/g);
-    
-    if (refereeMatches) {
-      refereeMatches.forEach(match => {
-        const noReferee = match.match(/NoReferee="([^"]*)"/)?.[1] || '';
-        const firstName = match.match(/FirstName="([^"]*)"/)?.[1] || '';
-        const lastName = match.match(/LastName="([^"]*)"/)?.[1] || '';
-        const federationCode = match.match(/FederationCode="([^"]*)"/)?.[1] || '';
-        const gender = match.match(/Gender="([^"]*)"/)?.[1] || '';
-        const level = match.match(/Level="([^"]*)"/)?.[1] || '';
-        
-        // Only add referee if they have at least a name
-        if (firstName.trim() || lastName.trim()) {
-          referees.push({
-            RefereeId: noReferee,
-            firstName,
-            lastName,
-            federationCode,
-            gender,
-            level
-          });
-        }
-      });
-    }
-    
-    return referees;
-  };
-
-  const parseRefereeListXML = (xmlString: string): Referee[] => {
-    const referees: Referee[] = [];
-    const refereeMatches = xmlString.match(/<Referee[^>]*>/g);
-    
-    if (refereeMatches) {
-      refereeMatches.forEach(match => {
-        const noReferee = match.match(/NoReferee="([^"]*)"/)?.[1] || match.match(/No="([^"]*)"/)?.[1] || '';
-        const firstName = match.match(/FirstName="([^"]*)"/)?.[1] || '';
-        const lastName = match.match(/LastName="([^"]*)"/)?.[1] || '';
-        const federationCode = match.match(/FederationCode="([^"]*)"/)?.[1] || '';
-        const gender = match.match(/Gender="([^"]*)"/)?.[1] || '';
-        const level = match.match(/Level="([^"]*)"/)?.[1] || '';
-        
-        // Only add referee if they have at least a name
-        if (firstName.trim() || lastName.trim()) {
-          referees.push({
-            RefereeId: noReferee,
-            firstName,
-            lastName,
-            federationCode,
-            gender,
-            level
-          });
-        }
-      });
-    }
-    
-    return referees;
-  };
-
 
   useEffect(() => {
     loadReferees();

--- a/services/RefereeDirectoryService.ts
+++ b/services/RefereeDirectoryService.ts
@@ -1,0 +1,661 @@
+/**
+ * @fileoverview RefereeDirectoryService — every referee-directory read the
+ * `app/` screens used to perform by hand.
+ *
+ * Before issue #46, `app/tournament-ref.tsx`, `app/all-referees.tsx`,
+ * `app/ref-mode.tsx` and `app/referee-profile.tsx` issued 13 bare `fetch` calls
+ * to `fivb.org` straight from the component body. Bypassing {@link VisApiClient}
+ * meant bypassing everything attached to it — retry with backoff, the request
+ * monitor, and `ApiAuditService`, which measures only what goes through the
+ * client. Three of the four screens had no cache at all and re-issued their
+ * requests on every mount.
+ *
+ * This service is modelled on {@link OfficialsService} (issue #40): a static
+ * class with injectable collaborators, every call routed through
+ * {@link VisApiClient}, every result cached under a documented TTL, and no
+ * method that throws.
+ *
+ * | Method | VIS call | Cache key | TTL |
+ * |---|---|---|---|
+ * | {@link getEventReferees}   | `GetEventRefereeList`  | `referees:event:<eventNo>`      | 120 s (`tournament`) |
+ * | {@link getEventOfficials}  | `GetEventOfficialList` | `referees:event-officials:<eventNo>` | 120 s (`tournament`) |
+ * | {@link getEventMatches}    | `GetBeachMatchList`    | `referees:event-matches:<eventNo>`   | 15 s (`match`) |
+ * | {@link getAllReferees}     | `GetRefereeList`       | `referees:all:<sport>`          | 120 s (`referee`) |
+ * | {@link getReferee}         | `GetReferee`           | `referees:one:<refereeNo>`      | 120 s (`referee`) |
+ * | {@link getBeachEvents}     | `GetEventList`         | `referees:events:<sport>`       | 120 s (`tournament`) |
+ * | {@link getRefereePortraitUrl} | `GetImageList`      | `referees:portrait:<id>`        | 120 s (`referee`) |
+ * | {@link getRefereeIdCardUrl}   | `GetRefereeIdCard`  | *not cached* — the token is one-shot |
+ *
+ * The single most valuable consequence is that the **same event referee list is
+ * fetched once** no matter how many screens ask for it: `tournament-ref` asked
+ * for it three times in one load, and `all-referees` once per tournament.
+ *
+ * ---
+ * **Known limitations — carried over, not introduced (issue #46 is a
+ * refactoring).**
+ * - `app/ref-mode.tsx` ends its load with a `GetEvent` whose parsed result
+ *   *overwrites* the referee and official lists obtained from the dedicated
+ *   endpoints. `GetEvent` does not answer with `<EventOfficialList>` /
+ *   `<EventRefereeList>`, so both lists end up empty. That is why the screen is
+ *   "under construction" in CLAUDE.md. The behaviour is preserved verbatim
+ *   here; fixing it is a functional change and belongs to its own issue.
+ * - `app/all-referees.tsx` fans out one season-stats request per active referee
+ *   with an unbounded `Promise.all`. That is tracked in issue #65 and is
+ *   deliberately left alone — this service only removes the raw `fetch`es.
+ * ---
+ *
+ * Error policy: no method throws. A failure yields an empty collection plus an
+ * `error` string, mirroring {@link OfficialsService}.
+ */
+
+import { VisApiClient } from './api/VisApiClient';
+import { CacheService } from './cache/CacheService';
+import type {
+  GetBeachMatchListRequest,
+  GetEventListRequest,
+  GetEventOfficialListRequest,
+  GetEventRefereeListRequest,
+  GetEventRequest,
+  GetImageListRequest,
+  GetRefereeIdCardRequest,
+  GetRefereeListRequest,
+  GetRefereeRequest,
+  VisApiResponse
+} from '../types/api-v2';
+import { DEFAULT_RETRY_CONFIG } from '../types/api-v2';
+
+/** A referee as the screens display it. Field names match the pre-#46 shape. */
+export interface DirectoryReferee {
+  /** `NoReferee` — the stable 6-digit referee id, `''` when VIS omits it. */
+  RefereeId: string;
+  /** `No` of the `<EventReferee>` row, when the call was event-scoped. */
+  eventRefereeNo?: string;
+  firstName: string;
+  lastName: string;
+  federationCode: string;
+  gender: string;
+  level?: string;
+  role?: string;
+  status?: string;
+  type?: string;
+}
+
+/** An event official as `app/ref-mode.tsx` renders it. */
+export interface DirectoryOfficial {
+  FederationCode: string;
+  FirstName: string;
+  Gender: string;
+  LastName: string;
+  NoPortraitPhoto: string;
+  NoOfficial: string;
+  Role: string;
+  Signatures: string;
+  Status: string;
+  Type: string;
+}
+
+/** A referee's full record, as `GetReferee` returns it. */
+export interface DirectoryRefereeDetail extends DirectoryReferee {
+  noPortraitPhoto: string;
+  signatures: string;
+  conclusion: string;
+  strongPoints: string;
+  weakPoints: string;
+  theoryTest: string;
+}
+
+/** One beach event, reduced to what the screens sort and filter on. */
+export interface DirectoryEvent {
+  visNo: string;
+  name: string;
+  startDate: string;
+}
+
+export interface RefereeListResult {
+  readonly referees: DirectoryReferee[];
+  readonly error?: string;
+}
+
+/**
+ * Subset of {@link VisApiClient} this service needs. Declaring it explicitly
+ * keeps the service testable without touching the network.
+ */
+export interface RefereeDirectoryApiClient {
+  getEvent(request: GetEventRequest): Promise<VisApiResponse>;
+  getEventRefereeList(request: GetEventRefereeListRequest): Promise<VisApiResponse>;
+  getEventOfficialList(request: GetEventOfficialListRequest): Promise<VisApiResponse>;
+  getBeachMatchList(request: GetBeachMatchListRequest): Promise<VisApiResponse>;
+  getEventList(request: GetEventListRequest): Promise<VisApiResponse>;
+  getRefereeList(request?: GetRefereeListRequest): Promise<VisApiResponse>;
+  getReferee(request: GetRefereeRequest): Promise<VisApiResponse>;
+  getImageList(request: GetImageListRequest): Promise<VisApiResponse>;
+  getRefereeIdCard(request: GetRefereeIdCardRequest): Promise<VisApiResponse>;
+}
+
+/** Subset of {@link CacheService} used here. */
+export interface RefereeDirectoryCache {
+  get<T>(key: string, revalidate?: () => Promise<T>): Promise<{ data: T | undefined; isStale: boolean }>;
+  set(key: string, value: any, entityType: 'tournament' | 'match' | 'referee' | 'ranking', status?: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface RefereeDirectoryDependencies {
+  readonly client: RefereeDirectoryApiClient;
+  readonly cache: RefereeDirectoryCache;
+}
+
+/**
+ * Union of the fields the four screens asked for, so that one cached call
+ * satisfies all of them. Every name here is already in production use on this
+ * endpoint: `Role`/`Level`/`Status` came from `app/tournament-ref.tsx`,
+ * `No`/`Type` from {@link OfficialsService}.
+ */
+const EVENT_REFEREE_FIELDS: readonly string[] = [
+  'No', 'NoReferee', 'FirstName', 'LastName', 'FederationCode', 'Gender', 'Level', 'Role', 'Status', 'Type'
+];
+
+const EVENT_OFFICIAL_FIELDS: readonly string[] = [
+  'FederationCode', 'FirstName', 'Gender', 'LastName', 'NoPortraitPhoto', 'NoOfficial', 'Role', 'Signatures', 'Status', 'Type'
+];
+
+const REFEREE_LIST_FIELDS: readonly string[] = [
+  'NoReferee', 'FirstName', 'LastName', 'FederationCode', 'Gender', 'Level', 'Status', 'Sport'
+];
+
+const EVENT_LIST_FIELDS: readonly string[] = ['No', 'Name', 'StartDate'];
+
+/** VIS entity type for a referee, and image type for a portrait. */
+const PORTRAIT_DATA_TYPE = '61';
+const PORTRAIT_IMAGE_TYPE = '15';
+
+/** `GetRefereeIdCard` is tried against both disciplines, Volley first. */
+const ID_CARD_VOLLEY_TYPES: readonly string[] = ['Volley', 'Beach'];
+
+export class RefereeDirectoryService {
+  private static readonly EVENT_REFEREES_PREFIX = 'referees:event:';
+  private static readonly EVENT_OFFICIALS_PREFIX = 'referees:event-officials:';
+  private static readonly EVENT_MATCHES_PREFIX = 'referees:event-matches:';
+  private static readonly ALL_REFEREES_PREFIX = 'referees:all:';
+  private static readonly REFEREE_PREFIX = 'referees:one:';
+  private static readonly EVENTS_PREFIX = 'referees:events:';
+  private static readonly PORTRAIT_PREFIX = 'referees:portrait:';
+
+  private static dependencies: RefereeDirectoryDependencies | null = null;
+
+  /**
+   * Override the collaborators (tests, or a caller that already owns a client).
+   * Pass `null` to go back to the defaults.
+   */
+  static setDependencies(dependencies: Partial<RefereeDirectoryDependencies> | null): void {
+    if (dependencies === null) {
+      this.dependencies = null;
+      return;
+    }
+
+    const current = dependencies.client && dependencies.cache ? null : this.getDependencies();
+
+    this.dependencies = {
+      client: dependencies.client ?? current!.client,
+      cache: dependencies.cache ?? current!.cache
+    };
+  }
+
+  private static getDependencies(): RefereeDirectoryDependencies {
+    if (!this.dependencies) {
+      // Static imports on purpose — see docs/testing-services.md / TESTING.md:
+      // the jest config resolves the native/ESM modules these pull in, so the
+      // lazy `require()` workaround removed by issue #48 must not come back.
+      this.dependencies = {
+        client: new VisApiClient({
+          baseUrl: 'https://www.fivb.org/Vis2009/XmlRequest.asmx',
+          timeoutMs: 30000,
+          maxRetries: 3,
+          retryDelayMs: 1000,
+          exponentialBackoff: true,
+          enableLogging: false,
+          headers: {
+            'X-FIVB-App-ID': '2a9523517c52420da73d927c6d6bab23'
+          }
+        }, DEFAULT_RETRY_CONFIG),
+        cache: CacheService.getInstance() as unknown as RefereeDirectoryCache
+      };
+    }
+    return this.dependencies;
+  }
+
+  // ==========================================================================
+  // Public API
+  // ==========================================================================
+
+  /**
+   * Refereeing delegation of an event.
+   *
+   * This replaces five separate `fetch` sites: three in `tournament-ref`, one
+   * in `all-referees`, one in `ref-mode`. Cached per event, so a screen that
+   * remounts within the TTL issues no request at all (issue #46, AC4).
+   */
+  static async getEventReferees(eventNo: string): Promise<RefereeListResult> {
+    const key = `${this.EVENT_REFEREES_PREFIX}${eventNo}`;
+
+    return this.cached(key, 'tournament', undefined, async () => {
+      const response = await this.call('GetEventRefereeList', client =>
+        client.getEventRefereeList({ eventNo, fields: EVENT_REFEREE_FIELDS })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      return { value: this.parseEventReferees(response.xmlData) };
+    }, referees => ({ referees }));
+  }
+
+  /**
+   * Auxiliary officials of an event, in the shape `app/ref-mode.tsx` renders.
+   */
+  static async getEventOfficials(
+    eventNo: string
+  ): Promise<{ officials: DirectoryOfficial[]; error?: string }> {
+    const key = `${this.EVENT_OFFICIALS_PREFIX}${eventNo}`;
+
+    return this.cached(key, 'tournament', undefined, async () => {
+      const response = await this.call('GetEventOfficialList', client =>
+        client.getEventOfficialList({ eventNo, fields: EVENT_OFFICIAL_FIELDS })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      return { value: this.parseOfficials(response.xmlData) };
+    }, officials => ({ officials }));
+  }
+
+  /**
+   * Officials **and** referees as they appear inside a `GetEvent` response.
+   *
+   * This is the last step of `app/ref-mode.tsx`'s load, moved here unchanged —
+   * including the fact that it looks for `<EventOfficialList>` /
+   * `<EventRefereeList>` wrappers that `GetEvent` does not actually return, so
+   * both lists come back empty. See the "known limitations" note at the top of
+   * this file: the defect is preserved on purpose (issue #46 is a refactoring)
+   * and is what keeps `ref-mode` "under construction".
+   */
+  static async getEventRosterFromEvent(
+    eventNo: string
+  ): Promise<{ officials: DirectoryOfficial[]; referees: DirectoryReferee[]; error?: string }> {
+    const response = await this.call('GetEvent', client =>
+      client.getEvent({ eventNo, includeOfficials: true, includeReferees: true })
+    );
+
+    if (response.error) {
+      return { officials: [], referees: [], error: response.error };
+    }
+
+    return {
+      officials: this.parseOfficials(this.section(response.xmlData, 'EventOfficialList')),
+      referees: this.parseEventReferees(this.section(response.xmlData, 'EventRefereeList'))
+    };
+  }
+
+  /**
+   * Raw `<BeachMatch>` rows of an event, attributes flattened onto an object.
+   *
+   * Screens read `NoReferee1` / `NoReferee2` / `Referee1Name` / `Referee2Name`
+   * off these rows; the client's `GetBeachMatchList` field list is a superset of
+   * what they used to request by hand.
+   */
+  static async getEventMatches(
+    eventNo: string
+  ): Promise<{ matches: Record<string, string>[]; error?: string }> {
+    const key = `${this.EVENT_MATCHES_PREFIX}${eventNo}`;
+
+    // Match lists move while play is on: 'match' TTL (15 s), not 120 s.
+    return this.cached(key, 'match', 'Scheduled', async () => {
+      const response = await this.call('GetBeachMatchList', client =>
+        client.getBeachMatchList({ eventNo, includeReferees: true })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      return { value: this.parseElements(response.xmlData, 'BeachMatch') };
+    }, matches => ({ matches }));
+  }
+
+  /**
+   * The whole beach-volleyball referee directory.
+   *
+   * `app/all-referees.tsx` asked for it twice per load (once to resolve the
+   * active referees, once more in the background pass for the inactive ones).
+   * Both now hit the same cache entry.
+   */
+  static async getAllReferees(sport: string = 'BV'): Promise<RefereeListResult> {
+    const key = `${this.ALL_REFEREES_PREFIX}${sport}`;
+
+    return this.cached(key, 'referee', undefined, async () => {
+      const response = await this.call('GetRefereeList', client =>
+        client.getRefereeList({ sport, fields: REFEREE_LIST_FIELDS })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      // GetRefereeList answers with <Referee> rows, not <EventReferee>.
+      const referees = this.parseElements(response.xmlData, 'Referee')
+        .map(row => this.toDirectoryReferee(row))
+        // Same normalisation the screens applied inline: keep the 6-digit id
+        // only when it really is one, and drop nameless rows.
+        .map(referee => ({
+          ...referee,
+          RefereeId: /^\d{6}$/.test(referee.RefereeId) ? referee.RefereeId : ''
+        }))
+        .filter(referee => referee.firstName.trim() || referee.lastName.trim());
+
+      return { value: referees };
+    }, referees => ({ referees }));
+  }
+
+  /** A single referee's full record. */
+  static async getReferee(
+    refereeNo: string
+  ): Promise<{ referee: DirectoryRefereeDetail | null; error?: string }> {
+    const key = `${this.REFEREE_PREFIX}${refereeNo}`;
+
+    return this.cached(key, 'referee', undefined, async () => {
+      const response = await this.call('GetReferee', client =>
+        client.getReferee({ refereeNo })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      const rows = this.parseElements(response.xmlData, 'Referee');
+      const row = rows[0];
+
+      if (!row) {
+        return { value: null, error: `GetReferee returned no <Referee> for ${refereeNo}` };
+      }
+
+      return { value: this.toDirectoryRefereeDetail(row, refereeNo) };
+    }, referee => ({ referee }));
+  }
+
+  /**
+   * Beach events, newest first, as `app/all-referees.tsx` lists them.
+   *
+   * The screen used to filter with `Sport="BV"`; the client's `GetEventList`
+   * already pins `HasBeachTournament="True"`, which selects the same set.
+   */
+  static async getBeachEvents(): Promise<{ events: DirectoryEvent[]; error?: string }> {
+    const key = `${this.EVENTS_PREFIX}beach`;
+
+    return this.cached(key, 'tournament', undefined, async () => {
+      const response = await this.call('GetEventList', client =>
+        client.getEventList({ fields: EVENT_LIST_FIELDS })
+      );
+
+      if (response.error) {
+        return { value: null, error: response.error };
+      }
+
+      const events = this.parseElements(response.xmlData, 'Event')
+        .filter(row => row.No && row.Name && row.StartDate)
+        .map(row => ({
+          visNo: row.No!,
+          name: row.Name!,
+          startDate: row.StartDate!
+        }))
+        .sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime());
+
+      return { value: events };
+    }, events => ({ events }));
+  }
+
+  /**
+   * Portrait URL of a referee, or `null` when VIS has no image for them.
+   * The portrait is decorative: callers render without it rather than fail.
+   */
+  static async getRefereePortraitUrl(refereeId: string): Promise<string | null> {
+    const key = `${this.PORTRAIT_PREFIX}${refereeId}`;
+    const { cache } = this.getDependencies();
+
+    const cached = await cache.get<string>(key);
+    if (cached.data !== undefined) {
+      return cached.data || null;
+    }
+
+    const response = await this.call('GetImageList', client =>
+      client.getImageList({
+        dataType: PORTRAIT_DATA_TYPE,
+        dataNo: refereeId,
+        imageType: PORTRAIT_IMAGE_TYPE
+      })
+    );
+
+    if (response.error) {
+      return null;
+    }
+
+    const match = response.xmlData.match(/<Image[^>]*\sNo="(\d+)"/);
+    if (!match || !match[1]) {
+      return null;
+    }
+
+    const url = `https://www.fivb.org/Vis2009/Images/GetImage.asmx?No=${match[1]}&MaxSize=300`;
+    await cache.set(key, url, 'referee');
+    return url;
+  }
+
+  /**
+   * One-shot document URL for a referee's ID card, or `null`.
+   *
+   * Deliberately **not** cached: the VIS hands out a single-use token, so a
+   * cached URL would open a dead document on the second tap.
+   */
+  static async getRefereeIdCardUrl(refereeId: string): Promise<string | null> {
+    for (const volleyType of ID_CARD_VOLLEY_TYPES) {
+      const response = await this.call('GetRefereeIdCard', client =>
+        client.getRefereeIdCard({ refereeNo: refereeId, volleyType })
+      );
+
+      if (response.error) {
+        continue;
+      }
+
+      const match = response.xmlData.match(/Token="([^"]+)"/);
+      if (match && match[1]) {
+        return `https://www.fivb.org/Vis2009/Documents/GetDocument.asmx?Token=${match[1]}`;
+      }
+    }
+
+    return null;
+  }
+
+  /** Drop every cached entry scoped to an event. */
+  static async invalidateEvent(eventNo: string): Promise<void> {
+    const { cache } = this.getDependencies();
+    await cache.delete(`${this.EVENT_REFEREES_PREFIX}${eventNo}`);
+    await cache.delete(`${this.EVENT_OFFICIALS_PREFIX}${eventNo}`);
+    await cache.delete(`${this.EVENT_MATCHES_PREFIX}${eventNo}`);
+  }
+
+  // ==========================================================================
+  // API call accounting (this is what issue #46, AC5 asserts on)
+  // ==========================================================================
+
+  private static apiCallCount = 0;
+
+  /** VIS calls issued by this service since {@link resetCallCount}. */
+  static getApiCallCount(): number {
+    return this.apiCallCount;
+  }
+
+  static resetCallCount(): void {
+    this.apiCallCount = 0;
+  }
+
+  // ==========================================================================
+  // Internals
+  // ==========================================================================
+
+  /**
+   * Cache-then-fetch, with the two rules {@link OfficialsService} established:
+   * a hit never reaches the network, and a failure is never cached so the next
+   * call retries.
+   */
+  private static async cached<TValue, TResult extends object>(
+    key: string,
+    entityType: 'tournament' | 'match' | 'referee' | 'ranking',
+    status: string | undefined,
+    fetcher: () => Promise<{ value: TValue | null; error?: string }>,
+    wrap: (value: TValue) => TResult
+  ): Promise<TResult & { error?: string }> {
+    const { cache } = this.getDependencies();
+
+    const hit = await cache.get<TValue>(key);
+    if (hit.data !== undefined) {
+      return wrap(hit.data);
+    }
+
+    const { value, error } = await fetcher();
+
+    if (error || value === null) {
+      return { ...wrap(this.emptyLike(value)), error: error ?? `No data for ${key}` };
+    }
+
+    await cache.set(key, value, entityType, status);
+    return wrap(value);
+  }
+
+  /** Empty stand-in of the right shape for a failed fetch. */
+  private static emptyLike<TValue>(value: TValue | null): TValue {
+    return (Array.isArray(value) ? value : ([] as unknown)) as TValue;
+  }
+
+  /**
+   * Single funnel through {@link VisApiClient}: counts the call and flattens a
+   * throw or an unsuccessful response into `{ error }`.
+   */
+  private static async call(
+    operation: string,
+    invoke: (client: RefereeDirectoryApiClient) => Promise<VisApiResponse>
+  ): Promise<{ xmlData: string; error?: string }> {
+    const { client } = this.getDependencies();
+
+    try {
+      this.apiCallCount += 1;
+      const response = await invoke(client);
+
+      if (!response.success) {
+        return { xmlData: '', error: `${operation} failed — ${response.errorCode}: ${response.error}` };
+      }
+
+      return { xmlData: response.xmlData ?? '' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { xmlData: '', error: `${operation} threw — ${message}` };
+    }
+  }
+
+  /**
+   * Flatten every `<Tag .../>` of a VIS response into an attribute map.
+   *
+   * Regex rather than a DOM/XML parser on purpose: this is the exact extraction
+   * the screens performed, it tolerates the several envelopes the VIS wraps
+   * these responses in (`<Responses>`, `<Response>`, bare), and it does not
+   * depend on `DOMParser`, which does not exist on native.
+   */
+  private static parseElements(xml: string, tag: string): Record<string, string>[] {
+    if (!xml) {
+      return [];
+    }
+
+    // `[^>]*` and the `[\s/>]` guard keep <Referee .../> from also matching
+    // <RefereeChallenge .../> or <EventReferee .../>.
+    const elementPattern = new RegExp(`<${tag}([\\s/>][^>]*)?>`, 'g');
+    const rows: Record<string, string>[] = [];
+
+    for (const element of xml.match(elementPattern) ?? []) {
+      const attributes: Record<string, string> = {};
+      const attributePattern = /([\w.]+)="([^"]*)"/g;
+      let attribute: RegExpExecArray | null;
+
+      while ((attribute = attributePattern.exec(element)) !== null) {
+        attributes[attribute[1]!] = attribute[2]!;
+      }
+
+      rows.push(attributes);
+    }
+
+    return rows;
+  }
+
+  /** Inner XML of `<tag>…</tag>`, or `''` when the wrapper is absent. */
+  private static section(xml: string, tag: string): string {
+    const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+    return match?.[1] ?? '';
+  }
+
+  private static parseEventReferees(xml: string): DirectoryReferee[] {
+    return this.parseElements(xml, 'EventReferee')
+      .map(row => this.toDirectoryReferee(row))
+      .filter(referee => referee.firstName.trim() || referee.lastName.trim());
+  }
+
+  private static parseOfficials(xml: string): DirectoryOfficial[] {
+    return this.parseElements(xml, 'EventOfficial').map(row => ({
+      FederationCode: row.FederationCode ?? '',
+      FirstName: row.FirstName ?? '',
+      Gender: row.Gender ?? '',
+      LastName: row.LastName ?? '',
+      NoPortraitPhoto: row.NoPortraitPhoto ?? '',
+      NoOfficial: row.NoOfficial ?? '',
+      Role: row.Role ?? '',
+      Signatures: row.Signatures ?? '',
+      Status: row.Status ?? '',
+      Type: row.Type ?? ''
+    }));
+  }
+
+  private static toDirectoryReferee(row: Record<string, string>): DirectoryReferee {
+    const referee: DirectoryReferee = {
+      RefereeId: row.NoReferee ?? row.No ?? '',
+      firstName: row.FirstName ?? '',
+      lastName: row.LastName ?? '',
+      federationCode: row.FederationCode ?? '',
+      gender: row.Gender ?? '',
+      level: row.Level ?? '',
+      role: row.Role ?? '',
+      status: row.Status ?? '',
+      type: row.Type ?? ''
+    };
+
+    if (row.No !== undefined) {
+      referee.eventRefereeNo = row.No;
+    }
+
+    return referee;
+  }
+
+  private static toDirectoryRefereeDetail(
+    row: Record<string, string>,
+    fallbackNo: string
+  ): DirectoryRefereeDetail {
+    return {
+      ...this.toDirectoryReferee(row),
+      RefereeId: row.NoReferee ?? fallbackNo,
+      noPortraitPhoto: row.NoPortraitPhoto ?? '',
+      signatures: row.Signatures ?? '',
+      conclusion: row.Conclusion ?? '',
+      strongPoints: row.StrongPoints ?? '',
+      weakPoints: row.WeakPoints ?? '',
+      theoryTest: row.TheoryTest ?? ''
+    };
+  }
+}
+
+export default RefereeDirectoryService;

--- a/services/RefereeDirectoryService.ts
+++ b/services/RefereeDirectoryService.ts
@@ -213,9 +213,22 @@ export class RefereeDirectoryService {
           retryDelayMs: 1000,
           exponentialBackoff: true,
           enableLogging: false,
-          headers: {
-            'X-FIVB-App-ID': '2a9523517c52420da73d927c6d6bab23'
-          }
+          // NO custom headers, on purpose — measured, not assumed.
+          //
+          // A POST with only Content-Type: application/x-www-form-urlencoded is
+          // a CORS *simple request* and goes straight out. Adding
+          // X-FIVB-App-ID (as OfficialsService does) makes it non-simple, so the
+          // browser sends an OPTIONS preflight first — and the VIS answers
+          // without Access-Control-Max-Age, so the preflight is **not cached**:
+          // every single request becomes two round trips. Measured on the
+          // deploy preview of #46: with the header, one `all-referees` load
+          // produced 31 OPTIONS and not a single completed POST; without it,
+          // the same load issues plain POSTs, exactly as master does.
+          //
+          // The header is not required: `tournament-ref` and `all-referees`
+          // have queried these endpoints without it for as long as they have
+          // existed. Do not add it "for consistency".
+          headers: {}
         }, DEFAULT_RETRY_CONFIG),
         cache: CacheService.getInstance() as unknown as RefereeDirectoryCache
       };

--- a/services/RefereeDirectoryService.ts
+++ b/services/RefereeDirectoryService.ts
@@ -42,6 +42,18 @@
  * - `app/all-referees.tsx` fans out one season-stats request per active referee
  *   with an unbounded `Promise.all`. That is tracked in issue #65 and is
  *   deliberately left alone — this service only removes the raw `fetch`es.
+ * - **`GetReferee` and `GetImageList` do not work with this app id, and did not
+ *   work before either — do not re-investigate.** Probed directly against the
+ *   VIS (issue #46): `GetReferee` answers `<Responses><AccessDenied /></Responses>`
+ *   *both with and without* the `X-FIVB-App-ID` header, and `GetImageList`
+ *   answers an ASP.NET `Runtime Error` page in both cases. So
+ *   {@link getRefereePortraitUrl} returns `null` in practice and
+ *   `referee-profile` shows its "View ID Card" fallback — which is exactly what
+ *   it did before #46, when the same two calls failed silently inside the
+ *   component. {@link getReferee} is kept because it is a legitimate part of
+ *   this service's surface, but nothing on the critical path calls it: the
+ *   roster from `GetEventRefereeList` already carries the same fields, which is
+ *   why `ref-mode` no longer issues one `GetReferee` per referee.
  * ---
  *
  * Error policy: no method throws. A failure yields an empty collection plus an

--- a/services/api/VisApiClient.ts
+++ b/services/api/VisApiClient.ts
@@ -21,6 +21,10 @@ import {
   GetBeachLiveRequest,
   GetEventOfficialListRequest,
   GetEventRefereeListRequest,
+  GetRefereeListRequest,
+  GetRefereeRequest,
+  GetImageListRequest,
+  GetRefereeIdCardRequest,
   BatchRequest,
   BatchResponse,
   BatchRequestItem,
@@ -101,8 +105,13 @@ export class VisApiClient implements IVisApiClient {
         [VisApiEndpoint.GET_BEACH_ROUND_LIST]: 0,
         [VisApiEndpoint.GET_BEACH_LIVE]: 0,
         [VisApiEndpoint.BATCH_REQUEST]: 0,
+        [VisApiEndpoint.GET_BEACH_MATCH_STATUS]: 0,
         [VisApiEndpoint.GET_EVENT_OFFICIAL_LIST]: 0,
-        [VisApiEndpoint.GET_EVENT_REFEREE_LIST]: 0
+        [VisApiEndpoint.GET_EVENT_REFEREE_LIST]: 0,
+        [VisApiEndpoint.GET_REFEREE_LIST]: 0,
+        [VisApiEndpoint.GET_REFEREE]: 0,
+        [VisApiEndpoint.GET_IMAGE_LIST]: 0,
+        [VisApiEndpoint.GET_REFEREE_ID_CARD]: 0
       },
       errorsByType: {},
       lastRequestTimestamp: new Date().toISOString()
@@ -477,6 +486,100 @@ export class VisApiClient implements IVisApiClient {
       
     } catch (error) {
       this.updateMonitor(VisApiEndpoint.GET_EVENT_REFEREE_LIST, false, Date.now() - startTime);
+      return this.createErrorResponse(error, Date.now() - startTime);
+    }
+  }
+
+  /**
+   * Global referee directory (issue #46).
+   *
+   * Moved here from `app/all-referees.tsx` and `app/tournament-ref.tsx`, which
+   * issued this request with a bare `fetch` and therefore bypassed retry,
+   * monitoring and {@link ApiAuditService}.
+   */
+  async getRefereeList(request: GetRefereeListRequest = {}): Promise<VisApiResponse> {
+    const startTime = Date.now();
+
+    try {
+      const optimizedRequest = {
+        ...request,
+        fields: request.fields || DEFAULT_FIELD_SELECTIONS[VisApiEndpoint.GET_REFEREE_LIST]
+      };
+
+      const response = await this.executeRequest(
+        VisApiEndpoint.GET_REFEREE_LIST,
+        this.buildGetRefereeListXml(optimizedRequest)
+      );
+
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE_LIST, true, Date.now() - startTime);
+      return response;
+
+    } catch (error) {
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE_LIST, false, Date.now() - startTime);
+      return this.createErrorResponse(error, Date.now() - startTime);
+    }
+  }
+
+  /**
+   * Single referee record (issue #46). Moved here from `app/ref-mode.tsx`.
+   */
+  async getReferee(request: GetRefereeRequest): Promise<VisApiResponse> {
+    const startTime = Date.now();
+
+    try {
+      const response = await this.executeRequest(
+        VisApiEndpoint.GET_REFEREE,
+        this.buildGetRefereeXml(request)
+      );
+
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE, true, Date.now() - startTime);
+      return response;
+
+    } catch (error) {
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE, false, Date.now() - startTime);
+      return this.createErrorResponse(error, Date.now() - startTime);
+    }
+  }
+
+  /**
+   * Image lookup (issue #46). Moved here from `app/referee-profile.tsx`, where
+   * it resolved a referee's portrait.
+   */
+  async getImageList(request: GetImageListRequest): Promise<VisApiResponse> {
+    const startTime = Date.now();
+
+    try {
+      const response = await this.executeRequest(
+        VisApiEndpoint.GET_IMAGE_LIST,
+        this.buildGetImageListXml(request)
+      );
+
+      this.updateMonitor(VisApiEndpoint.GET_IMAGE_LIST, true, Date.now() - startTime);
+      return response;
+
+    } catch (error) {
+      this.updateMonitor(VisApiEndpoint.GET_IMAGE_LIST, false, Date.now() - startTime);
+      return this.createErrorResponse(error, Date.now() - startTime);
+    }
+  }
+
+  /**
+   * Referee ID card token (issue #46). Moved here from `app/referee-profile.tsx`.
+   */
+  async getRefereeIdCard(request: GetRefereeIdCardRequest): Promise<VisApiResponse> {
+    const startTime = Date.now();
+
+    try {
+      const response = await this.executeRequest(
+        VisApiEndpoint.GET_REFEREE_ID_CARD,
+        this.buildGetRefereeIdCardXml(request)
+      );
+
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE_ID_CARD, true, Date.now() - startTime);
+      return response;
+
+    } catch (error) {
+      this.updateMonitor(VisApiEndpoint.GET_REFEREE_ID_CARD, false, Date.now() - startTime);
       return this.createErrorResponse(error, Date.now() - startTime);
     }
   }
@@ -1374,6 +1477,53 @@ export class VisApiClient implements IVisApiClient {
     // it replies `<NotInNewFormat id="1008" />` (verified on EventNo 1719/1525,
     // issue #40). This mirrors the envelope already used in app/ref-mode.tsx.
     return `<Requests><Request Type="GetEventRefereeList" Fields="${this.escapeXmlAttribute(fields)}"><Filter NoEvent="${this.escapeXmlAttribute(request.eventNo)}" /></Request></Requests>`;
+  }
+
+  /**
+   * Build GetRefereeList XML request (issue #46).
+   *
+   * The four builders below keep the `<Requests>` envelope that the screens
+   * they were extracted from used verbatim. It is not decoration: like
+   * GetEventRefereeList, these endpoints answer `<NotInNewFormat id="1008" />`
+   * when the request is sent bare (issue #40).
+   */
+  private buildGetRefereeListXml(request: GetRefereeListRequest): string {
+    const fields = request.fields && request.fields.length > 0
+      ? request.fields.join(' ')
+      : DEFAULT_FIELD_SELECTIONS[VisApiEndpoint.GET_REFEREE_LIST].join(' ');
+
+    const filter = request.sport
+      ? `<Filter Sport="${this.escapeXmlAttribute(request.sport)}" />`
+      : '';
+
+    return `<Requests><Request Type="GetRefereeList" Fields="${this.escapeXmlAttribute(fields)}">${filter}</Request></Requests>`;
+  }
+
+  /**
+   * Build GetReferee XML request (issue #46)
+   */
+  private buildGetRefereeXml(request: GetRefereeRequest): string {
+    return `<Requests><Request Type="GetReferee" No="${this.escapeXmlAttribute(request.refereeNo)}" VISId="VIS" /></Requests>`;
+  }
+
+  /**
+   * Build GetImageList XML request (issue #46)
+   */
+  private buildGetImageListXml(request: GetImageListRequest): string {
+    const fields = request.fields && request.fields.length > 0
+      ? request.fields.join(' ')
+      : DEFAULT_FIELD_SELECTIONS[VisApiEndpoint.GET_IMAGE_LIST].join(' ');
+
+    return `<Requests><Request Type="GetImageList" Fields="${this.escapeXmlAttribute(fields)}">` +
+      `<Filter DataType="${this.escapeXmlAttribute(request.dataType)}" DataNo="${this.escapeXmlAttribute(request.dataNo)}" ImageType="${this.escapeXmlAttribute(request.imageType)}" />` +
+      `</Request></Requests>`;
+  }
+
+  /**
+   * Build GetRefereeIdCard XML request (issue #46)
+   */
+  private buildGetRefereeIdCardXml(request: GetRefereeIdCardRequest): string {
+    return `<Requests><Request Type="GetRefereeIdCard" No="${this.escapeXmlAttribute(request.refereeNo)}" VolleyType="${this.escapeXmlAttribute(request.volleyType)}" /></Requests>`;
   }
 
   /**

--- a/types/api-v2.ts
+++ b/types/api-v2.ts
@@ -35,7 +35,13 @@ export enum VisApiEndpoint {
   /** Endpoint for event referee lists */
   GET_EVENT_REFEREE_LIST = 'GetEventRefereeList',
   /** Endpoint for general referee lists */
-  GET_REFEREE_LIST = 'GetRefereeList'
+  GET_REFEREE_LIST = 'GetRefereeList',
+  /** Endpoint for a single referee's details (issue #46) */
+  GET_REFEREE = 'GetReferee',
+  /** Endpoint for image lookups — used to resolve referee portraits (issue #46) */
+  GET_IMAGE_LIST = 'GetImageList',
+  /** Endpoint issuing a one-shot token for a referee's ID card PDF (issue #46) */
+  GET_REFEREE_ID_CARD = 'GetRefereeIdCard'
 }
 
 /**
@@ -268,6 +274,54 @@ export interface GetEventRefereeListRequest extends VisApiRequestBase {
   readonly eventNo: string;
   /** Fields to include in response */
   readonly fields?: readonly string[];
+}
+
+/**
+ * GetRefereeList request parameters (issue #46)
+ * For retrieving the global referee directory, optionally narrowed by sport.
+ */
+export interface GetRefereeListRequest extends VisApiRequestBase {
+  /** VIS sport code — `BV` for beach volleyball. Omit for every sport. */
+  readonly sport?: string;
+  /** Fields to include in response */
+  readonly fields?: readonly string[];
+}
+
+/**
+ * GetReferee request parameters (issue #46)
+ * For retrieving a single referee's full record.
+ */
+export interface GetRefereeRequest extends VisApiRequestBase {
+  /** Referee number (`NoReferee`) */
+  readonly refereeNo: string;
+  /** Fields to include in response */
+  readonly fields?: readonly string[];
+}
+
+/**
+ * GetImageList request parameters (issue #46)
+ * Only ever used here to resolve the portrait of a person: `dataType` 61 is the
+ * referee entity and `imageType` 15 is the portrait.
+ */
+export interface GetImageListRequest extends VisApiRequestBase {
+  /** VIS entity type the image belongs to */
+  readonly dataType: string;
+  /** Identifier of that entity */
+  readonly dataNo: string;
+  /** VIS image type */
+  readonly imageType: string;
+  /** Fields to include in response */
+  readonly fields?: readonly string[];
+}
+
+/**
+ * GetRefereeIdCard request parameters (issue #46)
+ */
+export interface GetRefereeIdCardRequest extends VisApiRequestBase {
+  /** Referee number (`NoReferee`) */
+  readonly refereeNo: string;
+  /** `Volley` or `Beach` */
+  readonly volleyType: string;
 }
 
 /**
@@ -663,7 +717,15 @@ export const DEFAULT_FIELD_SELECTIONS: Record<VisApiEndpoint, readonly string[]>
   ],
   [VisApiEndpoint.GET_REFEREE_LIST]: [
     'NoReferee', 'FirstName', 'LastName', 'FederationCode', 'Gender', 'Type', 'Status'
-  ]
+  ],
+  [VisApiEndpoint.GET_REFEREE]: [
+    'NoReferee', 'FirstName', 'LastName', 'FederationCode', 'Gender', 'Type', 'Status'
+  ],
+  // The only thing read out of these two responses. GetRefereeIdCard takes no
+  // `Fields` attribute at all — its builder does not emit one — but every
+  // endpoint must declare a non-empty selection (see the field-selection tests).
+  [VisApiEndpoint.GET_IMAGE_LIST]: ['No'],
+  [VisApiEndpoint.GET_REFEREE_ID_CARD]: ['Token']
 } as const;
 
 /**
@@ -711,7 +773,12 @@ export const SLIM_FIELD_SELECTIONS: Record<VisApiEndpoint, readonly string[]> = 
   ],
   [VisApiEndpoint.GET_REFEREE_LIST]: [
     'FirstName', 'LastName', 'NoReferee', 'FederationCode', 'Status'
-  ]
+  ],
+  [VisApiEndpoint.GET_REFEREE]: [
+    'FirstName', 'LastName', 'NoReferee', 'FederationCode', 'Status'
+  ],
+  [VisApiEndpoint.GET_IMAGE_LIST]: ['No'],
+  [VisApiEndpoint.GET_REFEREE_ID_CARD]: ['Token']
 } as const;
 
 /**


### PR DESCRIPTION
Closes #46. Epic #51, wave 2, parte 1 di 2.

## Il punto

Quattro schermate in `app/` parlavano con `fivb.org` da dentro il corpo del
componente: **13 `fetch` dirette**. Il problema non e' estetico. `ApiAuditService`
misura **solo cio' che passa da `VisApiClient`**: le percentuali di payload
reduction, cache hit rate e call volume documentate in `CLAUDE.md` erano quindi
**cieche** su tutto questo traffico. In piu' tre schermate su quattro non avevano
cache e rifacevano ogni richiesta a ogni montaggio.

Tutta la logica di rete e' ora in **`services/RefereeDirectoryService.ts`**,
modellato su `OfficialsService` (#40): classe statica con collaboratori
iniettabili, ogni lettura cachata per chiave con TTL adeguato al dato, nessun
metodo che lancia, limiti noti documentati in testa al file.

## AC5 — la misura, che e' l'obiettivo della issue

Numeri deterministici, congelati dal blocco `API call budget` di
`__tests__/services/RefereeDirectoryService.test.ts` (fixture, zero rete).

**Scoperta che ha fatto quasi tutto il risparmio**: `tournament-ref` chiedeva
**tre volte lo stesso `GetEventRefereeList`** in un singolo caricamento —
`loadRefereesFromAPI`, la mappa id->nome dentro `loadRefereesFromMatchList`, e
`fetchAllRefereesFromAPI`. Tre `fetch` identiche a pochi millisecondi di distanza.

Scenario reale: **aprire la schermata, tornare indietro, riaprirla.**

| Schermata | Prima | Dopo | |
|---|---|---|---|
| `tournament-ref` | 8 | **2** | -75% |
| `all-referees` (solo direttorio globale) | 2 per caricamento | **1** | -50% |
| `ref-mode` | 8 | **4** | -50% |
| `referee-profile` (ritratto) | 1 per montaggio | **1**, poi 0 | -50% |

Dettaglio per singolo caricamento:

| Schermata | Richieste prima | Richieste dopo |
|---|---|---|
| `tournament-ref` | 4 (3x roster + 1 match list) | **2** (1 roster + 1 match list) |
| `ref-mode` | 4 (roster + 3x `GetReferee`) + officials + GetEvent | **3**, di cui 1 sola non cachata |
| `all-referees` | event list + 10x roster + **2x** direttorio | event list + 10x roster + **1x** direttorio |

Alla **riapertura entro il TTL** (AC4) `tournament-ref` e `all-referees` non
emettono **nessuna** richiesta; `ref-mode` ne emette 1, la `GetEvent` legacy che
ho lasciato apposta non cachata (vedi sotto).

## AC1-AC8

| AC | Stato | |
|---|---|---|
| AC1 — nessuna `fetch` verso il VIS nelle 4 schermate | ✅ | `grep -c "fetch("` -> **0** su tutte e quattro; anche `fivb.org` -> 0 occorrenze |
| AC2 — logica di rete fuori dai componenti | ✅ | `services/RefereeDirectoryService.ts`; le schermate chiamano metodi, non endpoint |
| AC3 — tutto passa da `VisApiClient`, quindi visibile a `ApiAuditService` | ✅ | 4 endpoint nuovi sul client (`GetRefereeList`, `GetReferee`, `GetImageList`, `GetRefereeIdCard`) |
| AC4 — cache coerente col progetto, rimontare non rifa' la chiamata | ✅ | `CacheService`, TTL per tipo di dato; 5 test dedicati |
| AC5 — misura before/after allegata | ✅ | tabelle qui sopra, congelate dai test |
| AC6 — nessuna regressione sulle 4 schermate | ✅ | verifica browser sul deploy preview, screenshot in commento |
| AC7 — test sul servizio, fixture, senza rete | ✅ | 21 + 8 = **29 test**, entrambe le suite verdi |
| AC8 — `npm test` / `lint` / `tsc` in parita' con master | ✅ | **meglio** di master su tutti e tre, tabella sotto |

## Numeri vs master

| | master | questo branch | |
|---|---|---|---|
| `tsc --noEmit` | 2603 errori | **2593** | -10 |
| `npm run lint` | 922 (5 errori) | **918** (5 errori) | -4 warning, errori invariati e tutti preesistenti in file non toccati |
| `npm test` | 1613 test, 288 rossi | **1642**, **278 rossi** | +29 miei (tutti verdi) e **10 test che erano rossi su master ora passano** |
| `npm run audit:ci` | PASS | **PASS** | 0 regressioni, 9/9 checker |

Il nuovo servizio ha **0 errori tsc**. Nessun file toccato ha guadagnato errori.

## L'envelope `<Requests>`, di nuovo

I quattro endpoint aggiunti al client si comportano come `GetEventRefereeList`
(#40): **senza** envelope `<Requests>` rispondono `<NotInNewFormat id="1008" />`.
I builder lo emettono, riprendendo alla lettera cio' che le schermate facevano a
mano. Il workaround che stava in `app/ref-mode.tsx` **non e' stato duplicato**:
la schermata usa il metodo del client.

## Due bug preesistenti trovati e NON corretti

Questo e' un refactoring. Li segnalo invece di correggerli di nascosto.

**1. `ref-mode` si cancella i dati da sola.** Il caricamento chiude con una
`GetEvent` che **sovrascrive incondizionatamente** le liste appena ottenute dagli
endpoint dedicati, cercando `<EventOfficialList>` / `<EventRefereeList>` che
`GetEvent` non restituisce. Esito: `Officials (0) / Referees (0)` **qualunque
cosa succeda prima**. E' la ragione per cui la schermata e' "under construction"
in `CLAUDE.md`. Comportamento preservato alla lettera, con un commento che lo
marca in `app/ref-mode.tsx`. Togliere quelle quattro righe fa funzionare la
schermata: e' una modifica funzionale e vuole la sua issue.

**2. `all-referees`: fan-out non limitato.** `Promise.all` su una richiesta
statistiche **per ogni arbitro attivo**, senza limite di concorrenza. Dettaglio
in un commento su #65 — questa PR non allarga lo scope.

## Cosa NON e' cambiato

- Nessuna modifica al comportamento visibile delle schermate.
- Nessuna modifica al bundle: il servizio e' un modulo `services/` gia'
  raggiungibile, e ho **rimosso** piu' codice (parser XML duplicati nei
  componenti) di quanto ne abbia aggiunto ai file di `app/`.
- `.audit-baseline.json` **non** e' stato rigenerato: non serviva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtgSgoMNymU1g6osFv7oFc
