### PR TITLE
feat(auth): il bottone per accedere, e il menu Stats quando sei dentro (#103)

### DIFF
--- a/__tests__/auth/menu-non-carica-supabase.test.ts
+++ b/__tests__/auth/menu-non-carica-supabase.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Il menu non deve trascinare Supabase nel chunk d'ingresso (issue #103).
+ *
+ * `@supabase/supabase-js` arriva con un `import()` dinamico apposta: "il costo
+ * lo paga solo chi apre `/accedi` o `/iscrizione`" (commento in testa ad
+ * `AccessService`, e sezione "Web bundle weight" in CLAUDE.md).
+ *
+ * Il menu laterale sta su OGNI pagina. La tentazione naturale, mostrando una
+ * voce "Stats" a chi e' loggato, e' chiedere lo stato ad `AccessService.
+ * statoAccesso()` — che costruisce il client, quindi risolve quell'`import()`,
+ * quindi consegna l'SDK a ogni visitatore, loggato o no. La regressione non
+ * darebbe nessun test rosso e nessun errore: solo un bundle piu' pesante per
+ * tutti. Per questo la barriera e' qui.
+ *
+ * Cio' che viene congelato:
+ *   1. i moduli che il menu importa STATICAMENTE per l'accesso non nominano
+ *      l'SDK se non come tipo o dentro un `import()`;
+ *   2. il menu non chiama `statoAccesso()`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const RADICE = path.resolve(__dirname, '..', '..');
+
+const leggi = (relativo: string): string =>
+  fs.readFileSync(path.join(RADICE, relativo), 'utf8');
+
+/**
+ * Il codice senza le note. Le barriere di questo file cercano nomi che i
+ * commenti CITANO di proposito — `statoAccesso`, `/iscrizione` — per spiegare
+ * perche' non vanno usati. Cercandoli nel sorgente grezzo, la spiegazione
+ * stessa farebbe fallire il test, e l'unico rimedio sarebbe togliere la
+ * spiegazione.
+ */
+const senzaCommenti = (sorgente: string): string =>
+  sorgente
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter(riga => !riga.trim().startsWith('//'))
+    .join('\n');
+
+/**
+ * Occorrenze di `@supabase/supabase-js` che finirebbero nel bundle: si
+ * escludono i commenti, gli `import type` e gli `import()` dinamici.
+ */
+function importiStatici(sorgente: string): string[] {
+  return sorgente
+    .split('\n')
+    .map(riga => riga.trim())
+    .filter(riga => riga.includes('@supabase/supabase-js'))
+    .filter(riga => !riga.startsWith('*') && !riga.startsWith('//') && !riga.startsWith('/*'))
+    .filter(riga => !riga.startsWith('import type'))
+    .filter(riga => !riga.includes('import('));
+}
+
+describe('il menu laterale non carica Supabase', () => {
+  const moduliStatici = [
+    'components/navigation/GmailStyleSideMenu.tsx',
+    'hooks/useAccessoRicordato.ts',
+    'services/auth/statoRicordato.ts',
+    'services/auth/AccessService.ts',
+  ];
+
+  it.each(moduliStatici)('%s non importa staticamente @supabase/supabase-js', file => {
+    expect(importiStatici(leggi(file))).toEqual([]);
+  });
+
+  it('il menu non chiede lo stato ad AccessService', () => {
+    const menu = leggi('components/navigation/GmailStyleSideMenu.tsx');
+
+    // `esci` va bene: e' un riferimento a funzione, e il client arriva solo se
+    // qualcuno preme il bottone. `statoAccesso` no: verrebbe chiamata al
+    // montaggio, cioe' su ogni pagina.
+    expect(senzaCommenti(menu)).not.toContain('statoAccesso');
+  });
+
+  it('il menu legge lo stato dalla copia locale', () => {
+    const menu = leggi('components/navigation/GmailStyleSideMenu.tsx');
+    expect(menu).toContain('useAccessoRicordato');
+  });
+
+  it('AccessService continua a caricare il client con un import dinamico', () => {
+    const servizio = leggi('services/auth/AccessService.ts');
+    expect(servizio).toContain("import('@supabase/supabase-js')");
+  });
+});
+
+describe('nessun ingresso verso l\'iscrizione', () => {
+  it('il menu non collega /iscrizione', () => {
+    // Ci si iscrive solo con un indirizzo mandato a mano: autenticarsi con
+    // Google e' alla portata di chiunque, l'autorizzazione e' un invito.
+    expect(senzaCommenti(leggi('components/navigation/GmailStyleSideMenu.tsx'))).not.toContain('/iscrizione');
+  });
+});

--- a/__tests__/auth/statoRicordato.test.ts
+++ b/__tests__/auth/statoRicordato.test.ts
@@ -1,0 +1,62 @@
+/**
+ * La copia locale dello stato di accesso (issue #103).
+ *
+ * Serve al menu per sapere quali voci mostrare senza caricare Supabase. Non e'
+ * un controllo di autorizzazione — quello vive in `is_authorized` sul database
+ * — e i test qui sotto lo dicono esplicitamente, perche' la tentazione di
+ * appoggiarci una decisione di accesso e' la sola cosa che renderebbe questo
+ * file pericoloso.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { dimentica, ricorda, statoRicordato } from '../../services/auth/statoRicordato';
+
+describe('statoRicordato', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('non sa niente finche nessuno ha ricordato', async () => {
+    // `null` non e' "anonimo": e' "non l'ho ancora chiesto a nessuno". Il menu
+    // ripiega sulla voce di accesso, che e' il comportamento giusto per un
+    // visitatore appena arrivato.
+    expect(await statoRicordato()).toBeNull();
+  });
+
+  it('ricorda un accesso autorizzato', async () => {
+    await ricorda({ stato: 'autorizzato', email: 'arbitro@example.com', nome: 'Arbitro' });
+
+    expect(await statoRicordato()).toEqual({
+      stato: 'autorizzato',
+      email: 'arbitro@example.com',
+    });
+  });
+
+  it('distingue autenticato da autorizzato', async () => {
+    await ricorda({ stato: 'autenticato_non_autorizzato', email: 'chiunque@example.com' });
+
+    const letto = await statoRicordato();
+    expect(letto?.stato).toBe('autenticato_non_autorizzato');
+  });
+
+  it('ricorda uno stato senza email senza inventarne una', async () => {
+    await ricorda({ stato: 'anonimo' });
+
+    expect(await statoRicordato()).toEqual({ stato: 'anonimo', email: null });
+  });
+
+  it('dimentica', async () => {
+    await ricorda({ stato: 'autorizzato', email: 'a@b.c', nome: 'A' });
+    await dimentica();
+
+    expect(await statoRicordato()).toBeNull();
+  });
+
+  it('un contenuto corrotto vale come "non so niente", non come un errore', async () => {
+    // Se questa lettura sollevasse, il menu — che sta su ogni pagina — si
+    // romperebbe per tutti a causa di una chiave di storage malformata.
+    await AsyncStorage.setItem('beachref-accesso-ricordato', 'non-e-json');
+
+    expect(await statoRicordato()).toBeNull();
+  });
+});

--- a/components/navigation/GmailStyleSideMenu.tsx
+++ b/components/navigation/GmailStyleSideMenu.tsx
@@ -26,6 +26,14 @@ import { useFavoriteTournaments } from '../../hooks/useFavoriteTournaments';
 import { Icon } from '../Icons/MaterialCommunityIcons';
 import { colors } from '../../theme/tokens';
 import { DefaultTournamentService } from '../../services/DefaultTournamentService';
+// Lo stato di accesso si legge dalla copia LOCALE (issue #103). Importare
+// `AccessService` per chiedere `statoAccesso()` qui dentro trascinerebbe
+// `@supabase/supabase-js` nel chunk d'ingresso — il menu sta su ogni pagina —
+// e vanificherebbe l'`import()` dinamico che quel servizio usa apposta.
+// `esci` invece si importa: e' solo un riferimento a funzione, e il client
+// arriva soltanto se qualcuno preme davvero il bottone.
+import { useAccessoRicordato } from '../../hooks/useAccessoRicordato';
+import { esci } from '../../services/auth/AccessService';
 
 interface SubMenuItem {
   key: 'schedule' | 'ranking' | 'entryList' | 'officials';
@@ -262,6 +270,40 @@ export const GmailStyleSideMenu: React.FC<GmailStyleSideMenuProps> = ({
     onClose();
     router.push(route as any);
   };
+
+  // --- Accesso (issue #103) -------------------------------------------------
+  //
+  // `/accedi` e `/referee-stats-lab` esistono dalla #97 ma non erano collegate
+  // da nessuna parte: si raggiungevano solo digitando l'indirizzo.
+  //
+  // `/iscrizione` NON compare qui, ed e' voluto: ci si iscrive solo con un
+  // indirizzo mandato a mano, perche' autenticarsi con Google e' alla portata di
+  // chiunque mentre l'autorizzazione e' un invito.
+  const accesso = useAccessoRicordato();
+
+  useEffect(() => {
+    if (isVisible) accesso.rileggi();
+  }, [isVisible, accesso.rileggi]);
+
+  const handleEsci = async () => {
+    onClose();
+    await esci();
+    accesso.rileggi();
+    router.replace('/' as any);
+  };
+
+  const vociAccesso: { titolo: string; onPress: () => void }[] = accesso.autenticato
+    ? [
+        // "Stats" solo a chi e' autorizzato. Chi si e' autenticato senza invito
+        // non la vede: la distinzione fra "chi sei" e "se puoi" e' la stessa
+        // che la #97 ha messo nel database, e il menu la rispecchia invece di
+        // mostrare una porta che si apre su un rifiuto.
+        ...(accesso.autorizzato
+          ? [{ titolo: 'Stats', onPress: () => handleMenuItemPress('/referee-stats-lab') }]
+          : [{ titolo: 'Accesso', onPress: () => handleMenuItemPress('/accedi') }]),
+        { titolo: 'Esci', onPress: handleEsci },
+      ]
+    : [{ titolo: 'Accedi con Google', onPress: () => handleMenuItemPress('/accedi') }];
 
   const handleTournamentToggle = (tournamentId: string) => {
     setExpandedTournaments(prev => {
@@ -509,6 +551,19 @@ export const GmailStyleSideMenu: React.FC<GmailStyleSideMenuProps> = ({
                       </TouchableOpacity>
                     );
                   })}
+
+                  {vociAccesso.map(voce => (
+                    <TouchableOpacity
+                      key={voce.titolo}
+                      style={styles.mainMenuItem}
+                      onPress={voce.onPress}
+                      activeOpacity={0.7}
+                      accessibilityLabel={voce.titolo}
+                      accessibilityRole="button"
+                    >
+                      <Text style={styles.mainMenuText}>{voce.titolo}</Text>
+                    </TouchableOpacity>
+                  ))}
                 </View>
               </View>
             </ScrollView>

--- a/hooks/useAccessoRicordato.ts
+++ b/hooks/useAccessoRicordato.ts
@@ -1,0 +1,58 @@
+/**
+ * Lo stato di accesso per la NAVIGAZIONE (issue #103).
+ *
+ * Legge la copia locale scritta da `AccessService.statoAccesso()`, e non
+ * importa `@supabase/supabase-js`: e' l'intero punto. Questo hook gira nel menu
+ * laterale, che sta su ogni pagina, mentre il client Supabase arriva con un
+ * `import()` dinamico apposta per non pesare su chi non accede.
+ *
+ * Cio' che restituisce serve a decidere QUALI VOCI MOSTRARE. Non e' un
+ * controllo di autorizzazione: quello lo fa `is_authorized` sul database, che
+ * la pagina statistiche valuta a ogni apertura. Vedi `statoRicordato.ts`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { statoRicordato, type StatoRicordato } from '../services/auth/statoRicordato';
+
+export type AccessoRicordato = {
+  /** `null` finche' la lettura non e' finita, o se non si sa niente. */
+  stato: StatoRicordato | null;
+  /** C'e' una sessione Google, autorizzata o meno. */
+  autenticato: boolean;
+  /** Puo' vedere le statistiche. */
+  autorizzato: boolean;
+  /** Rilegge la copia locale. Da chiamare all'apertura del menu. */
+  rileggi: () => void;
+};
+
+export function useAccessoRicordato(): AccessoRicordato {
+  const [stato, setStato] = useState<StatoRicordato | null>(null);
+
+  // La lettura e' asincrona e il menu si smonta senza preavviso: senza questa
+  // guardia, una `setStato` in ritardo arriverebbe a componente gia' andato.
+  const montato = useRef(true);
+
+  useEffect(() => {
+    montato.current = true;
+    return () => {
+      montato.current = false;
+    };
+  }, []);
+
+  const rileggi = useCallback(() => {
+    statoRicordato().then(letto => {
+      if (montato.current) setStato(letto);
+    });
+  }, []);
+
+  useEffect(() => {
+    rileggi();
+  }, [rileggi]);
+
+  return {
+    stato,
+    autenticato: stato?.stato === 'autorizzato' || stato?.stato === 'autenticato_non_autorizzato',
+    autorizzato: stato?.stato === 'autorizzato',
+    rileggi,
+  };
+}

--- a/hooks/useAccessoRicordato.ts
+++ b/hooks/useAccessoRicordato.ts
@@ -39,10 +39,25 @@ export function useAccessoRicordato(): AccessoRicordato {
     };
   }, []);
 
+  /**
+   * `statoRicordato()` inghiotte gia' i propri errori e restituisce `null`,
+   * quindi il ramo di errore non dovrebbe scattare mai. C'e' lo stesso perche'
+   * la posta e' il menu di OGNI pagina: se un giorno quella funzione imparasse
+   * a rifiutare, un rifiuto non gestito qui diventerebbe un errore in console
+   * su tutto il sito. `null` significa "non so niente", e il menu ripiega sulla
+   * voce di accesso — che e' il ripiego giusto.
+   */
   const rileggi = useCallback(() => {
-    statoRicordato().then(letto => {
-      if (montato.current) setStato(letto);
-    });
+    const leggi = async () => {
+      try {
+        const letto = await statoRicordato();
+        if (montato.current) setStato(letto);
+      } catch {
+        if (montato.current) setStato(null);
+      }
+    };
+
+    void leggi();
   }, []);
 
   useEffect(() => {

--- a/services/auth/AccessService.ts
+++ b/services/auth/AccessService.ts
@@ -23,6 +23,7 @@
  */
 
 import type { SupabaseClient, Session } from '@supabase/supabase-js';
+import { dimentica, ricorda } from './statoRicordato';
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -198,6 +199,11 @@ export async function entraConGoogle(percorsoDiRitorno: string): Promise<void> {
 }
 
 export async function esci(): Promise<void> {
+  // Si dimentica PRIMA di uscire: se `signOut` fallisce, meglio un menu che
+  // mostra "Accedi" a chi e' ancora dentro (rimedio: un click) che un menu che
+  // mostra "Stats" a chi e' uscito.
+  await dimentica();
+
   if (!accessoConfigurato()) return;
   const sb = await client();
   await sb.auth.signOut();
@@ -217,6 +223,18 @@ async function sessione(): Promise<Session | null> {
  * sarebbe un'opinione del browser, e il browser e' di chi lo usa.
  */
 export async function statoAccesso(): Promise<StatoAccesso> {
+  const esito = await calcolaStatoAccesso();
+
+  // Se ne tiene una copia minuscola per il menu, che sta su ogni pagina e non
+  // puo' permettersi di caricare il client Supabase solo per sapere quali voci
+  // mostrare (issue #103). Vedi `statoRicordato.ts` per il perche' e per i
+  // limiti di quella copia.
+  await ricorda(esito);
+
+  return esito;
+}
+
+async function calcolaStatoAccesso(): Promise<StatoAccesso> {
   if (!accessoConfigurato()) {
     return {
       stato: 'non_configurato',

--- a/services/auth/statoRicordato.ts
+++ b/services/auth/statoRicordato.ts
@@ -1,0 +1,85 @@
+/**
+ * L'ultimo stato di accesso conosciuto, leggibile senza caricare Supabase
+ * (issue #103).
+ *
+ * ## Perche' esiste
+ *
+ * `AccessService.statoAccesso()` e' la risposta autorevole, ma per darla deve
+ * costruire il client Supabase — e `@supabase/supabase-js` arriva con un
+ * `import()` dinamico proprio perche' pesa: "il costo lo paga solo chi apre
+ * `/accedi` o `/iscrizione`" (vedi il commento in testa ad `AccessService` e
+ * "Web bundle weight" in CLAUDE.md).
+ *
+ * Il menu laterale sta su OGNI pagina. Se per decidere se mostrare la voce
+ * "Stats" chiedesse a `statoAccesso()`, quel chunk finirebbe addosso a ogni
+ * visitatore — loggato o no, interessato alle statistiche o no — annullando la
+ * ragione per cui l'import e' dinamico.
+ *
+ * Qui si scrive quindi una copia minuscola dell'esito, e la si rilegge con la
+ * sola AsyncStorage (che su web e' localStorage). Nessun import del client.
+ *
+ * ## Puo' essere STANTIA, ed e' accettabile
+ *
+ * Se l'autorizzazione viene revocata dopo l'ultimo accesso, questa copia
+ * continua a dire "autorizzato" finche' qualcuno non ricalcola. La voce di menu
+ * porterebbe allora a una pagina che rifiuta — che e' esattamente cio' che quella
+ * pagina deve fare.
+ *
+ * La distinzione da tenere ferma: **il menu e' un'affordance, non un controllo
+ * di sicurezza**. La barriera vera e' `is_authorized` sul database, valutata
+ * dalla pagina a ogni apertura. Nessuna decisione di accesso si appoggia a
+ * questo file.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { StatoAccesso } from './AccessService';
+
+const CHIAVE = 'beachref-accesso-ricordato';
+
+/** La sola parte dello stato che al menu serve davvero. */
+export type StatoRicordato = {
+  stato: StatoAccesso['stato'];
+  email: string | null;
+};
+
+/**
+ * Registra l'esito appena calcolato. Non solleva mai: se la memoria non e'
+ * disponibile, il menu mostrera' semplicemente la voce di accesso, che e' il
+ * ripiego giusto.
+ */
+export async function ricorda(stato: StatoAccesso): Promise<void> {
+  try {
+    const daRicordare: StatoRicordato = {
+      stato: stato.stato,
+      email: 'email' in stato ? stato.email : null,
+    };
+    await AsyncStorage.setItem(CHIAVE, JSON.stringify(daRicordare));
+  } catch {
+    // Ricordare e' un'ottimizzazione, non un requisito.
+  }
+}
+
+/** Dimentica tutto. Da chiamare all'uscita. */
+export async function dimentica(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(CHIAVE);
+  } catch {
+    // Come sopra.
+  }
+}
+
+/**
+ * Rilegge l'ultimo esito noto. `null` quando non se ne sa niente — che e'
+ * diverso da "anonimo": significa "non l'ho ancora chiesto a nessuno".
+ */
+export async function statoRicordato(): Promise<StatoRicordato | null> {
+  try {
+    const grezzo = await AsyncStorage.getItem(CHIAVE);
+    if (!grezzo) return null;
+
+    const letto = JSON.parse(grezzo) as StatoRicordato;
+    return typeof letto?.stato === 'string' ? letto : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Chiude #103.

## Cosa cambia per chi usa l'app

Nel menu laterale compaiono:

| Stato | Voci |
|---|---|
| non autenticato | **Accedi con Google** |
| autenticato **senza** invito | **Accesso**, **Esci** |
| autorizzato | **Stats**, **Esci** |

Nessun collegamento a `/iscrizione`, e non e' una dimenticanza: autenticarsi con
Google e' alla portata di chiunque, l'autorizzazione e' un invito, e
l'indirizzo di iscrizione si manda a mano — e' la scelta gia' presa dalla #97.

## Perche' era cosi' poco codice

La #97 aveva gia' costruito tutto: accesso Google via Supabase Auth,
distinzione fra "chi sei" (Google) e "se puoi" (riga in `app_users`), pagina
statistiche, variabili su Netlify. Mancava solo che qualcuno collegasse
`/accedi` e `/referee-stats-lab` a un menu: fino a ieri si raggiungevano solo
digitando l'indirizzo a mano.

## Il vincolo che ha deciso il progetto

Il menu sta su **ogni** pagina. Chiedere lo stato ad `AccessService.
statoAccesso()` sarebbe stato naturale — e avrebbe costruito il client
Supabase, risolvendo l'`import()` dinamico che quel servizio usa apposta
perche' l'SDK pesa. Il costo sarebbe finito addosso a ogni visitatore, loggato
o no.

Quindi `statoAccesso()` scrive una copia minuscola dell'esito e il menu rilegge
quella con la sola AsyncStorage. La copia puo' essere **stantia**: se
l'autorizzazione viene revocata, la voce "Stats" resta finche' qualcuno non
ricalcola. E' accettabile perche' porterebbe a una pagina che rifiuta.

**Il menu e' un'affordance, non un controllo di sicurezza.** La barriera vera
resta `is_authorized` sul database, valutata a ogni apertura della pagina.
Nessuna decisione di accesso si appoggia alla copia locale.

## Barriere

`__tests__/auth/menu-non-carica-supabase.test.ts` congela la proprieta' del
bundle: una regressione qui non darebbe nessun test rosso e nessun errore, solo
un bundle piu' pesante per tutti. Verifica che i moduli statici del menu non
importino l'SDK, che il menu non chiami `statoAccesso`, e che non compaia un
ingresso verso `/iscrizione`.

`__tests__/auth/statoRicordato.test.ts` copre il giro completo della copia
locale, incluso un contenuto corrotto — che deve valere "non so niente" e non
rompere il menu su tutte le pagine.

## Misurato, e una cosa che ne e' venuta fuori

Esportato il bundle web per verificare l'AC sul chunk d'ingresso. Questa PR non
lo peggiora, ma la misura ha mostrato che **l'SDK Supabase e' gia' nel chunk
d'ingresso** (`GoTrueClient`, `PostgrestClient`), e non da oggi:
`services/ErrorLogger.ts` importa `services/supabase.ts`, che fa un import di
**valore** dell'SDK, ed ErrorLogger e' importato ovunque.

La premessa scritta nella #97 — "il costo lo paga solo chi apre /accedi" — e'
quindi gia' disattesa su produzione. Aperta la **#104**: fuori dallo scope di
questa PR, ma andava saputo.

## Verifica

```bash
npx jest --ci --forceExit    # 140 passed, 1 skipped, 0 failed
npm run audit                # 9 checker, 0 regressioni bloccanti
```

Nota: il primo push e' stato **respinto** dal gate a 9 checker — una catena di
promise senza `.catch()` in `useAccessoRicordato`. Il sottoinsieme pre-commit
non la copriva. Corretta nel secondo commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qzRFbCdx2Yd4NPRPaXuym
