### PR TITLE
test: le fixture di assignmentDashboard smettono di misurare l'orologio (#107)

### DIFF
--- a/__tests__/utils/assignmentDashboard.test.ts
+++ b/__tests__/utils/assignmentDashboard.test.ts
@@ -17,8 +17,25 @@ import {
 } from '../../utils/assignmentDashboard';
 import { Assignment } from '../../types/assignments';
 
-// Mock assignments for testing
-const mockAssignments: Assignment[] = [
+// L'orologio e' congelato per l'intera suite, e le fixture sono costruite
+// *dopo* il congelamento (issue #107).
+//
+// Prima erano costruite all'import del modulo, relative a `Date.now()` reale.
+// Gli offset (+1h, +25h, -1h) descrivono uno scenario — "due assegnazioni
+// oggi, una domani, una conclusa" — che pero' e' vero solo se l'ora corrente
+// e' lontana dalla mezzanotte: dopo le ~23:00 locali "fra un'ora" cade nel
+// giorno successivo, e i due test che contano le assegnazioni di oggi
+// diventavano rossi. Non era un difetto di `getUpcomingAssignments`: era la
+// fixture che, a quell'ora, descriveva un altro scenario.
+//
+// Spostare l'offset non basta — qualunque scarto fisso prima o poi attraversa
+// la mezzanotte. L'istante e' costruito con il costruttore *locale*
+// (`new Date(2026, 5, 1, 12, ...)`) e non da una stringa ISO, cosi' e'
+// mezzogiorno in qualunque fuso orario: -1h e +1h restano nello stesso giorno
+// e +25h nel successivo ovunque giri la suite.
+const FROZEN_NOW = new Date(2026, 5, 1, 12, 0, 0); // 1 giugno 2026, mezzogiorno locale
+
+const createMockAssignments = (): Assignment[] => [
   {
     id: 'current-001',
     courtNumber: 1,
@@ -78,6 +95,17 @@ const mockAssignments: Assignment[] = [
 ];
 
 describe('assignmentDashboard utilities', () => {
+  let mockAssignments: Assignment[];
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: FROZEN_NOW });
+    mockAssignments = createMockAssignments();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('getCurrentAssignment', () => {
     it('should return explicitly current assignment', () => {
       const result = getCurrentAssignment(mockAssignments);
@@ -197,20 +225,14 @@ describe('assignmentDashboard utilities', () => {
   });
 
   describe('formatAssignmentTimeForDashboard', () => {
-    // The clock is frozen for this test. It reads `new Date()` here and the
-    // function under test reads `Date.now()` a moment later, so any millisecond
-    // elapsing between the two turns "30 min" into "29 min" — which is exactly
-    // how this suite came to be flaky in a full parallel run while passing in
-    // isolation (issue #61, AC8). Freezing time removes the race rather than
-    // widening the assertion.
-    beforeEach(() => {
-      jest.useFakeTimers({ now: new Date('2026-06-01T12:00:00Z') });
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
+    // Il congelamento dell'orologio, che questo blocco dichiarava per conto
+    // proprio, e' ora quello della suite intera (issue #107) — il motivo per
+    // cui serve qui resta valido e vale la pena ricordarlo: il test legge
+    // `new Date()` e la funzione sotto esame legge `Date.now()` un istante
+    // dopo, quindi qualunque millisecondo trascorso fra i due trasforma
+    // "30 min" in "29 min". E' cosi' che questa suite era diventata instabile
+    // in un run parallelo completo pur passando in isolamento (issue #61, AC8).
+    // Congelare il tempo elimina la corsa invece di allargare l'assert.
     it('should format time correctly for different durations', () => {
       const now = new Date();
 


### PR DESCRIPTION
Closes #107

## Il difetto

Le cinque assegnazioni di prova erano costruite **all'import del modulo**, relative a `Date.now()` reale, con offset di +10min, +5min, +1h, -1h e +25h. Quegli offset descrivono uno scenario — *"due assegnazioni oggi, una domani, una conclusa"* — che pero' e' vero solo lontano dalla mezzanotte: dopo le ~23:00 locali "fra un'ora" cade nel giorno successivo.

Non e' un difetto di `getUpcomingAssignments`: e' la fixture che, a quell'ora, prepara uno scenario diverso da quello che il test crede di aver preparato.

## Il fix

Le fixture diventano `createMockAssignments()`, chiamata da un `beforeEach` che **prima** congela l'orologio. I riferimenti nei test restano invariati.

L'istante e' costruito con il costruttore **locale** — `new Date(2026, 5, 1, 12, 0, 0)`, non una stringa ISO — cosi' e' mezzogiorno in *qualunque* fuso orario: -1h e +1h restano nello stesso giorno e +25h nel successivo ovunque giri la suite. Spostare l'offset non sarebbe bastato: qualunque scarto fisso prima o poi attraversa la mezzanotte.

Il `beforeEach` locale di `formatAssignmentTimeForDashboard` (che congelava per conto proprio, per la corsa della #61) diventa ridondante e viene assorbito da quello di suite; il commento che ne spiega la ragione resta.

## Verifica

Il difetto e' stato **riprodotto** congelando l'orologio alle 23:30 *prima* dell'import, sul file pre-fix:

| | |
|---|---|
| pre-fix, orologio 23:30 | **4 rossi** / 24 |
| post-fix, stesso orologio | **24 verdi** / 24 |

Sono 4, non 2. Oltre ai due riportati nella issue (osservati alle 23:07) cadono anche `getDashboardPriority > tertiary for far future` e `shouldScrollToAssignment > not scroll to far future`, perche' alle 23:30 `upcoming-001` non e' piu' ne' \"oggi\" ne' \"futuro lontano\".

> ⚠️ `TZ=America/Chicago` **non** e' un modo valido di fare questa verifica su Windows: Node ignora la variabile, la suite gira all'ora di Roma e passa per il motivo sbagliato. Verificato esplicitamente prima di scegliere la strada del congelamento pre-import.

## Acceptance criteria

- [x] I test non dipendono piu' dall'ora in cui girano
- [x] Verificato congelando l'orologio a un istante notturno (23:30) che prima li faceva fallire
- [x] `npm test` verde su due run consecutivi

```
Test Suites: 1 skipped, 140 passed, 140 of 141 total
Tests:       22 skipped, 2145 passed, 2167 total
```

Numeri identici su entrambi i run. I 22 skipped sono i sospesi della #101, non toccati qui.

Audit: PASS su tutti e 9 i checker, nessuna regressione vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtHCZUy32Vg41xVSc85CYy