### PR TITLE
test: jest sa montare react-native, e l'invariant ha un solo punto di taglio (#101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Testing
 - `npm test` - Run the jest suite
+- **Jest monta React Native** dalla issue #101 —
+  `render(React.createElement(TournamentList))` funziona. Non era vero prima:
+  qualunque `render()` moriva con `Invariant Violation:
+  __fbBatchedBridgeConfig is not set`, e il rimedio era sospendere il test.
+  Il taglio sta in `jest.native-modules.js`, che fornisce
+  `global.nativeModuleProxy` — il ramo che `NativeModules.js` prende **prima**
+  di sollevare l'invariant, cioe' il punto d'innesto previsto dal runtime.
+  **Non innestare `react-native/jest/setup.js`**: appende il runner (tentato
+  due volte, #94 e #101) e definisce `window`, che questo codebase vieta
+  perche' cinque moduli deducono di essere sul web dalla sua assenza (#94).
+  La barriera e' `__tests__/jest-native-modules.test.ts`; il perche' per esteso
+  e' in `TESTING.md`.
+- **I 28 test `.tsx` restano esclusi**, ma non per l'ambiente: si montano
+  tutti, e falliscono su asserzioni invecchiate (colori della palette,
+  `getByRole` di RNTL v13, conteggi di render). Numeri e famiglie nel commento
+  sopra l'esclusione in `jest.config.js`; il lavoro e' la issue #111.
 - **Prima di scrivere il test di un servizio, leggi `TESTING.md`.**
   `VisApiClient` e `CacheService` si importano **staticamente**: la config jest
   (`jest.config.js`, `__mocks__/`) risolve `expo/virtual/env`, `react-native-mmkv`

--- a/TESTING.md
+++ b/TESTING.md
@@ -122,6 +122,82 @@ Nota sul formato: il client invia il body come **form param URL-encoded**
 
 ---
 
+---
+
+# Montare componenti React Native (issue #101)
+
+```ts
+import { render } from '@testing-library/react-native';
+render(React.createElement(TournamentList));   // ✅ funziona
+```
+
+Fino alla #101 non funzionava: qualunque `render()` di un componente vero moriva
+con `Invariant Violation: __fbBatchedBridgeConfig is not set`.
+
+## Dove nasceva, e dove è stato tagliato
+
+La catena è `View → ViewNativeComponent → NativeComponentRegistry →
+getNativeComponentAttributes → processColor → Platform.ios →
+NativePlatformConstantsIOS → TurboModuleRegistry → NativeModules`. Il
+`jest.mock('react-native')` di `jest.env.js` **non la intercetta**, perché
+sostituisce l'export pubblico mentre quella catena passa dagli import *relativi
+interni* di react-native.
+
+Il punto d'innesto è `Libraries/BatchedBridge/NativeModules.js`, che solleva
+l'invariant **solo nel ramo `else`**:
+
+```js
+if (global.nativeModuleProxy) { NativeModules = global.nativeModuleProxy }
+else { invariant(global.__fbBatchedBridgeConfig, '...') }
+```
+
+`jest.native-modules.js` (in `setupFiles`, **prima** di `jest.env.js`) fornisce
+quel proxy: crea un modulo nativo finto su richiesta, con i metodi come
+`jest.fn()`. Nessuna patch a react-native e nessun elenco di moduli da tenere
+allineato.
+
+## Perché non il preset ufficiale
+
+`react-native/jest/setup.js` è la strada ovvia ed è stata tentata **due volte**,
+nella #94 e nella #101. Appende il runner, perché collide con il
+`jest.mock('react-native')` di `jest.env.js` (che fa `requireActual`). E
+comunque non sarebbe adottabile così com'è: alla riga 58 definisce
+`window: { value: global }`, che è esattamente ciò che `jest.env.js` **vieta**,
+con una misura a supporto (#94) — in questo codebase almeno cinque moduli
+deducono di girare su web dall'*assenza* di `window`.
+
+Se ti trovi a riprovarci, il vincolo da rispettare è quello, non il preset.
+
+## Due mock chirurgici, e perché
+
+| Mock | Ragione |
+|---|---|
+| `global.nativeModuleProxy` | Il taglio alla radice descritto sopra |
+| `Libraries/ReactNative/AppContainer` → ramo `-prod` | `<Modal>` monta `AppContainer`, che con `__DEV__` vero sceglie `AppContainer-dev`; quel ramo legge `window.__REACT_DEVTOOLS_GLOBAL_HOOK__` **a livello di modulo**. Il ramo `-prod` non legge nessun globale: è lo stesso componente meno LogBox, inspector e overlay di debug |
+
+Il mock ufficiale `react-native/jest/mockModal.js` non serve: passa da
+`mockComponent`, che fa `requireActual` di `Modal.js` e riesegue lo stesso
+import.
+
+## Cosa è verificato che si monti
+
+`__tests__/jest-native-modules.test.ts` monta `View`, `Text`, `ScrollView`,
+`ActivityIndicator`, `TextInput`, `Image`, `Pressable`, `TouchableOpacity`,
+`FlatList`, `Switch`, `Modal`, `Animated.View` e `RefreshControl`. **È la
+barriera**: se qualcuno tocca il setup, è lì che il danno diventa visibile,
+invece che in una suite a caso fra 140.
+
+## I test `.tsx` restano esclusi — e non per questo motivo
+
+`testPathIgnorePatterns` esclude ancora `/__tests__/.*\.tsx$`. Il commento
+storico diceva "React Native setup complexity", e **non è più vero**: misurati
+dopo la #101, quei 28 file si montano. Falliscono su asserzioni proprie —
+`getByRole('image')` che RNTL v13 non risolve più allo stesso modo, conteggi di
+render, testo cambiato. Vedi la nota in `jest.config.js` per i numeri e la
+issue che li riprende.
+
+---
+
 ## Regole
 
 1. **Mai** `require()` lazy nel codice di produzione per aggirare jest.

--- a/__tests__/integration/vis-to-database-sync.test.ts
+++ b/__tests__/integration/vis-to-database-sync.test.ts
@@ -146,30 +146,37 @@ const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 };
 
 /**
- * Sospesi: renderizzano alberi di componenti React Native VERI (issue #94).
+ * Ancora sospesi — ma NON piu' per il motivo dichiarato dalla #94.
  *
- * `render(<TournamentList/>)` non tocca solo React. `View` importa
- * `ViewNativeComponent` -> `NativeComponentRegistry` ->
- * `getNativeComponentAttributes` -> `processColor` -> `Platform.ios` ->
- * `NativePlatformConstantsIOS`, che chiede il modulo al `TurboModuleRegistry`
- * e muore con `Invariant Violation: __fbBatchedBridgeConfig is not set`. Non e'
- * un difetto del codice sotto test: e' che questa configurazione jest non sa
- * montare react-native. Mockare `Platform` e `StyleSheet` sull'export pubblico
- * — come fa `jest.env.js` — non basta, perche' quella catena passa dagli import
- * interni di react-native.
+ * Quel motivo era che jest non sapeva montare react-native: `render()` moriva
+ * con `Invariant Violation: __fbBatchedBridgeConfig is not set`. **La #101 lo
+ * ha risolto** (`jest.native-modules.js`), e la prova e' che i quattro test
+ * gemelli di `components/__tests__/TournamentList.migration.test.ts` — che
+ * montano lo STESSO `TournamentList` — sono tornati attivi e passano.
  *
- * E' la stessa ragione per cui `jest.config.js` esclude gia' TUTTI i test
- * `.tsx` ("React Native setup complexity"). Questi sono `.ts` solo perche'
- * usano `React.createElement` invece del JSX, quindi l'esclusione non li
- * prendeva — ma il limite e' identico.
+ * Riattivare questi dieci fa invece **appendere il runner**, e la causa e' nel
+ * test, non nell'ambiente. Ogni blocco:
  *
- * Innestare `react-native/jest/setup.js` e' stato tentato e ritirato: appende
- * il runner (>9 minuti su 2 suite, nessun output) perche' collide con il
- * `jest.mock('react-native')` di `jest.env.js`. Farlo funzionare e' un lavoro
- * a se', da aprire come issue dedicata; nel frattempo questi test sono sospesi
- * DICHIARATAMENTE invece di essere rossi per sempre.
+ *   1. precarica un `QueryClient` con `setQueryData(['tournaments'], ...)`,
+ *      `['matches']`, `['analytics','dashboard']`, con righe in **snake_case
+ *      di database** (`vis_tournament_no`, `start_main_draw`, `team1_player1`);
+ *   2. monta i componenti VERI — `TournamentList`, `MatchListV2`,
+ *      `AnalyticsDashboard` — senza mockare gli hook che li alimentano;
+ *   3. asserisce su stringhe gia' formattate (`'Rio de Janeiro, BRA'`,
+ *      `'Male'`, `'21-19'`, `'50%'`, `'4 records processed'`).
  *
- * Cio' che NON dipende dal rendering resta attivo: 'Data Consistency
+ * Nessuno dei tre passi combacia con l'interfaccia reale: le chiavi che gli
+ * hook interrogano non sono quelle, il formato non e' quello, e i componenti
+ * emettono comunque le proprie fetch — che trovano la `global.fetch` di
+ * `jest.env.js` a 503 e ripartono con il backoff.
+ *
+ * E' codice che **non e' mai stato eseguito**: prima della #94 moriva
+ * all'import per il JSX in un file `.ts`, dalla #94 e' sospeso. Non descrive
+ * un comportamento che si e' rotto, descrive un comportamento immaginato.
+ * Riscriverlo contro l'interfaccia vera e' un lavoro di natura diversa dalla
+ * #101 e ha una issue propria.
+ *
+ * Cio' che non dipende dal rendering resta attivo: 'Data Consistency
  * Validation' e 'Sync Service Performance Benchmarks' girano e passano.
  */
 const describeRenderingRN = describe.skip;

--- a/__tests__/jest-native-modules.test.ts
+++ b/__tests__/jest-native-modules.test.ts
@@ -1,0 +1,147 @@
+/**
+ * L'ambiente sa montare react-native (issue #101).
+ *
+ * Questa suite non esamina codice dell'applicazione: esamina la
+ * configurazione. Prima della #101 ogni riga qui sotto moriva con
+ * `Invariant Violation: __fbBatchedBridgeConfig is not set`, e il danno era
+ * distribuito su 14 test sospesi e 28 file `.tsx` esclusi — cioe' era
+ * invisibile come causa unica.
+ *
+ * Serve percio' un posto dove quella causa e' visibile per conto proprio. Se
+ * qualcuno tocca `jest.native-modules.js`, `jest.env.js` o i transform, il
+ * primo rosso deve comparire qui, con un nome che dice cosa e' successo, e non
+ * in una suite a caso fra le 140.
+ *
+ * L'elenco dei componenti non e' decorativo: `View` e' la radice della catena
+ * nativa, `ScrollView` / `ActivityIndicator` / `Text` sono quelli che la #101
+ * indicava come da verificare oltre a `View`, e `Modal` e' l'unico che il
+ * proxy dei moduli nativi da solo non salva (monta `AppContainer`, che nel
+ * ramo di sviluppo legge `window`).
+ */
+
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import {
+  ActivityIndicator,
+  Animated,
+  FlatList,
+  Image,
+  Modal,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Switch,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+// `React.createElement` invece del JSX: questo file e' un `.ts`, e il transform
+// per `.ts` non abilita il parsing JSX. Rinominarlo `.tsx` lo farebbe sparire
+// dal run — quelli sono esclusi da `testPathIgnorePatterns`, ed e' proprio
+// l'esclusione che questa suite esiste per rendere superflua un giorno.
+const e = React.createElement;
+
+describe("l'ambiente jest monta react-native", () => {
+  const componenti: [string, () => React.ReactElement][] = [
+    ['View', () => e(View, null, e(Text, null, 'contenuto'))],
+    ['Text', () => e(Text, null, 'contenuto')],
+    ['ScrollView', () => e(ScrollView, null, e(Text, null, 'contenuto'))],
+    ['ActivityIndicator', () => e(ActivityIndicator, { size: 'large' })],
+    ['TextInput', () => e(TextInput, { value: 'x', onChangeText: () => {} })],
+    ['Image', () => e(Image, { source: { uri: 'https://example.test/x.png' } })],
+    ['Pressable', () => e(Pressable, { onPress: () => {} }, e(Text, null, 'x'))],
+    ['TouchableOpacity', () => e(TouchableOpacity, { onPress: () => {} }, e(Text, null, 'x'))],
+    [
+      'FlatList',
+      () =>
+        e(FlatList as React.ComponentType<Record<string, unknown>>, {
+          data: [1, 2],
+          renderItem: ({ item }: { item: number }) => e(Text, null, String(item)),
+          keyExtractor: (item: number) => String(item),
+        }),
+    ],
+    ['Switch', () => e(Switch, { value: true, onValueChange: () => {} })],
+    ['Modal', () => e(Modal, { visible: true }, e(Text, null, 'contenuto'))],
+    ['Animated.View', () => e(Animated.View, { style: { opacity: 1 } }, e(Text, null, 'x'))],
+    [
+      'ScrollView + RefreshControl',
+      () =>
+        e(
+          ScrollView,
+          { refreshControl: e(RefreshControl, { refreshing: false, onRefresh: () => {} }) },
+          e(Text, null, 'contenuto')
+        ),
+    ],
+  ];
+
+  it.each(componenti)('monta %s', (_nome, crea) => {
+    expect(render(crea()).toJSON()).toBeTruthy();
+  });
+
+  it('rende visibile il testo dentro un albero annidato', () => {
+    const { getByText } = render(
+      e(View, null, e(ScrollView, null, e(View, null, e(Text, null, 'in fondo all albero'))))
+    );
+
+    expect(getByText('in fondo all albero')).toBeTruthy();
+  });
+
+  // Due livelli distinti, ed e' il punto di tutta la #101.
+  //
+  // L'export PUBBLICO di `react-native` e' sostituito da `jest.env.js`, che
+  // dichiara `Platform: { OS, select }` e nient'altro — niente `constants`.
+  // Quel mock non e' mai stato il problema e non e' mai stato la soluzione:
+  // la catena che sollevava l'invariant passa dai moduli INTERNI, che
+  // `jest.mock('react-native')` non intercetta.
+  //
+  // E' li' che il proxy dei moduli nativi lavora, ed e' li' che va verificato.
+  it("l'export pubblico di react-native resta quello dichiarato da jest.env.js", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Platform } = require('react-native');
+
+    expect(Platform.OS).toBe('ios');
+  });
+
+  // La versione dichiarata in `MODULE_CONSTANTS.PlatformConstants` e' quella
+  // vera del progetto (0.79.5) e non il `major: 1000` del preset ufficiale di
+  // react-native: un controllo di versione sotto test deve vedere la RN che
+  // c'e', non una inventata.
+  it('serve le costanti native al livello interno, dove nasceva l invariant', () => {
+    const proxy = (globalThis as { nativeModuleProxy?: Record<string, { getConstants(): Record<string, unknown> }> })
+      .nativeModuleProxy;
+
+    expect(proxy).toBeDefined();
+    expect(proxy!.PlatformConstants.getConstants().reactNativeVersion).toEqual(
+      expect.objectContaining({ major: 0, minor: 79 })
+    );
+    // `Dimensions.js` dereferenzia questo alla prima importazione: senza,
+    // `PixelRatio` muore con "Cannot read properties of undefined".
+    expect(proxy!.DeviceInfo.getConstants().Dimensions).toEqual(
+      expect.objectContaining({ screen: expect.any(Object), window: expect.any(Object) })
+    );
+  });
+
+  // Un modulo mai visto prima riceve comunque un metodo utilizzabile, ed e'
+  // sempre lo stesso `jest.fn()` a ogni lettura — cosi' un test puo'
+  // asserirci sopra invece di trovarsi un mock nuovo a ogni accesso.
+  it('inventa i moduli nativi che non conosce, in modo stabile', () => {
+    const proxy = (globalThis as { nativeModuleProxy?: Record<string, Record<string, unknown>> })
+      .nativeModuleProxy;
+
+    const primo = proxy!.UnModuloCheNonEsiste.unMetodoQualsiasi;
+    const secondo = proxy!.UnModuloCheNonEsiste.unMetodoQualsiasi;
+
+    expect(typeof primo).toBe('function');
+    expect(primo).toBe(secondo);
+  });
+
+  // La ragione per cui il preset ufficiale di react-native non e' adottabile
+  // qui: definisce `window`, e almeno cinque moduli di questo codebase
+  // deducono di girare su web dalla sua assenza (issue #94). Se un giorno
+  // qualcuno lo innesta, questo assert e' il primo a cadere.
+  it('non definisce window', () => {
+    expect(typeof (globalThis as { window?: unknown }).window).toBe('undefined');
+  });
+});

--- a/components/__tests__/TournamentList.migration.test.ts
+++ b/components/__tests__/TournamentList.migration.test.ts
@@ -77,22 +77,15 @@ const mockTournament = {
 };
 
 /**
- * Sospesa: renderizza un albero di componenti React Native VERO (issue #94).
+ * Sospesa dalla #94, riattivata dalla #101.
  *
- * Tutti e quattro i test chiamano `render(<TournamentList/>)`, e `View` importa
- * `ViewNativeComponent` -> `NativeComponentRegistry` ->
- * `getNativeComponentAttributes` -> `processColor` -> `Platform.ios` ->
- * `NativePlatformConstantsIOS`, che chiede il modulo al `TurboModuleRegistry`
- * e muore con `Invariant Violation: __fbBatchedBridgeConfig is not set`. Non e'
- * un difetto di `TournamentList` ne' di `useTournaments`: questa
- * configurazione jest non sa montare react-native, ed e' la stessa ragione per
- * cui `jest.config.js` esclude gia' tutti i test `.tsx`.
- *
- * Vedi la nota estesa in `__tests__/integration/vis-to-database-sync.test.ts`,
- * incluso il tentativo con `react-native/jest/setup.js` (appende il runner) e
- * il fatto che farlo funzionare va aperto come issue a se'.
+ * Tutti e quattro i test chiamano `render(<TournamentList/>)`, che moriva con
+ * `Invariant Violation: __fbBatchedBridgeConfig is not set`: non un difetto di
+ * `TournamentList` ne' di `useTournaments`, ma la configurazione jest che non
+ * sapeva montare react-native. Ora lo sa — `jest.native-modules.js` fornisce
+ * `global.nativeModuleProxy`, che e' il punto di innesto previsto dal runtime.
  */
-describe.skip('TournamentList Migration', () => {
+describe('TournamentList Migration', () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,13 @@
 const base = {
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  setupFiles: ['<rootDir>/jest.env.js'],
+  // L'ORDINE CONTA (issue #101): `jest.native-modules.js` deve girare per
+  // primo, perche' fornisce `global.nativeModuleProxy` — il ramo che
+  // `NativeModules.js` prende PRIMA di sollevare `Invariant Violation:
+  // __fbBatchedBridgeConfig is not set`. Deve essere in piedi quando il
+  // `jest.mock('react-native')` di `jest.env.js` fa `requireActual` e con esso
+  // carica il primo modulo nativo. Invertirli riporta l'invariant.
+  setupFiles: ['<rootDir>/jest.native-modules.js', '<rootDir>/jest.env.js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     // `babel-preset-expo` rewrites every `process.env.EXPO_PUBLIC_*` read into an
@@ -92,7 +98,30 @@ const base = {
     // gitignored (.gitignore:98) and `scripts/audit/config.ts` already excludes
     // `.claude/**`; jest was the last tool still reading it.
     '/\\.claude/',
-    '/__tests__/.*\\.tsx$', // Skip tsx test files for now due to React Native setup complexity
+    // I 28 test `.tsx` restano esclusi — ma NON piu' per "React Native setup
+    // complexity", che e' cio' che questa riga ha dichiarato fino alla #101 e
+    // che ora e' falso: l'ambiente monta react-native
+    // (`jest.native-modules.js`, barriera in `__tests__/jest-native-modules.test.ts`).
+    //
+    // Misurato dopo la #101, togliendo l'esclusione: 2 file verdi su 28, con
+    // ~148 test rossi. Le famiglie di fallimento, contate sull'output:
+    //
+    //   166  Unable to find an element with text     asserzioni su testo cambiato
+    //    64  Unable to find an element with role     RNTL v13 risolve i ruoli diversamente
+    //    56  toHaveStyle                             stili cambiati (palette "Titanium & Gold")
+    //    36  toHaveBeenCalledTimes                   conteggi di render non piu' veri
+    //    12  Cannot find module                      import verso file spostati o rimossi
+    //     4  Unable to find an element with testID
+    //
+    // e **zero** `__fbBatchedBridgeConfig`, **zero** `ReferenceError: window`.
+    // Cioe': si montano tutti, e sbagliano sulle proprie asserzioni, invecchiate
+    // in un anno in cui nessuno le eseguiva.
+    //
+    // Riabilitarli e' quindi un lavoro di manutenzione per file, non una
+    // questione di configurazione, e ha una issue propria. Riabilitarli in
+    // blocco qui aggiungerebbe ~148 rossi a una suite che la #94 ha appena
+    // portato a zero.
+    '/__tests__/.*\\.tsx$',
     // Supabase Edge Functions are Deno programs: their tests import
     // `https://deno.land/...` and use the `Deno` global. They are executed by
     // `deno test`, never by jest — running them here only produced noise.

--- a/jest.native-modules.js
+++ b/jest.native-modules.js
@@ -1,0 +1,133 @@
+// Rende montabili i componenti React Native sotto jest (issue #101).
+//
+// ── Il problema ────────────────────────────────────────────────────────────
+//
+// Renderizzare una `<View>` non tocca solo React. La catena e':
+//
+//   View -> ViewNativeComponent -> NativeComponentRegistry
+//        -> getNativeComponentAttributes -> processColor
+//        -> Platform.ios -> NativePlatformConstantsIOS
+//        -> TurboModuleRegistry.get -> NativeModules
+//        -> Invariant Violation: __fbBatchedBridgeConfig is not set
+//
+// Mockare `Platform` e `StyleSheet` sull'export pubblico di `react-native`,
+// come fa `jest.env.js`, non serve a niente qui: quella catena passa dagli
+// import RELATIVI INTERNI di react-native, non dall'export pubblico.
+//
+// ── Perche' non il preset ufficiale ────────────────────────────────────────
+//
+// La strada ovvia sarebbe `react-native/jest/setup.js`. E' stata tentata nella
+// #101 e ritirata: appende il runner (>9 minuti su due suite, nessun output)
+// perche' collide con il `jest.mock('react-native')` di `jest.env.js`, che fa
+// `requireActual`. E comunque non sarebbe adottabile cosi' com'e', perche' alla
+// riga 58 definisce
+//
+//   window: { value: global }
+//
+// che e' esattamente cio' che `jest.env.js` vieta, con una misura a supporto
+// (issue #94): in questo codebase almeno cinque moduli — `VisApiClient`,
+// `services/supabase.ts`, `app/_layout.tsx`, `utils/memoryProfiler.ts`,
+// `MatchListV2` — deducono di girare su web dall'ASSENZA di `window`.
+// Definirlo li fa credere di essere in un browser e porta suite verdi al rosso.
+//
+// ── Cosa fa invece questo file ─────────────────────────────────────────────
+//
+// Taglia la catena nel punto in cui nasce, che non e' `TurboModuleRegistry` ma
+// il modulo sotto di esso. `Libraries/BatchedBridge/NativeModules.js` (riga
+// ~181) solleva l'invariant SOLO nel ramo `else`:
+//
+//   if (global.nativeModuleProxy) { NativeModules = global.nativeModuleProxy }
+//   else { invariant(global.__fbBatchedBridgeConfig, '...') }
+//
+// Fornire `nativeModuleProxy` e' quindi il punto di innesto previsto dal
+// runtime stesso: un modulo nativo finto viene creato su richiesta, con i
+// metodi come `jest.fn()`. Nessuna patch a react-native, nessun mock da tenere
+// allineato a un elenco di moduli.
+//
+// Il file gira in `setupFiles`, PRIMA di `jest.env.js`: deve essere in piedi
+// quando il primo modulo di react-native viene importato.
+
+/* eslint-env jest */
+
+const nativeModuleMocks = {};
+
+// I moduli per cui `getConstants() -> {}` non basta, perche' il chiamante
+// dereferenzia subito il risultato. I valori vengono da
+// `react-native/jest/setup.js`, cosi' un test che asserisce su una dimensione
+// vede gli stessi numeri che vedrebbe con il preset ufficiale.
+const MODULE_CONSTANTS = {
+  // `Dimensions.js` fa `getConstants().Dimensions.screen` all'import, quindi
+  // senza queste `PixelRatio` muore con "Cannot read properties of undefined".
+  DeviceInfo: {
+    Dimensions: {
+      window: { fontScale: 2, height: 1334, scale: 2, width: 750 },
+      screen: { fontScale: 2, height: 1334, scale: 2, width: 750 },
+    },
+  },
+  // Letto da `Platform.ios.js`. La versione dichiarata e' quella reale del
+  // progetto (RN 0.79.5) e non il `major: 1000` del preset ufficiale: un
+  // controllo di versione sotto test deve vedere la versione vera.
+  PlatformConstants: {
+    forceTouchAvailable: false,
+    interfaceIdiom: 'phone',
+    isTesting: true,
+    osVersion: '17.0',
+    reactNativeVersion: { major: 0, minor: 79, patch: 5, prerelease: undefined },
+    systemName: 'iOS',
+  },
+};
+
+function makeNativeModule(name) {
+  const constants = MODULE_CONSTANTS[name] || {};
+  // Le costanti sono esposte sia da `getConstants()` sia come proprieta'
+  // dirette: la Old Architecture le leggeva nel secondo modo e diversi moduli
+  // di react-native lo fanno ancora.
+  const mod = { getConstants: () => constants, ...constants };
+
+  return new Proxy(mod, {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      if (typeof prop !== 'string') return undefined;
+      // Metodo mai visto: diventa un `jest.fn()` e resta lo stesso a ogni
+      // lettura, cosi' un test puo' asserire su di esso.
+      target[prop] = jest.fn();
+      return target[prop];
+    },
+  });
+}
+
+global.nativeModuleProxy = new Proxy(nativeModuleMocks, {
+  get(target, name) {
+    if (typeof name !== 'string') return undefined;
+    if (!(name in target)) target[name] = makeNativeModule(name);
+    return target[name];
+  },
+  has: () => true,
+});
+
+// `<Modal>` e' l'unico componente che il proxy non salva, e non per un modulo
+// nativo: monta `AppContainer`, che con `__DEV__` vero sceglie il ramo
+// `AppContainer-dev`. Quel ramo legge `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`
+// **a livello di modulo** (riga 31), e altrettanto fa
+// `DebuggingOverlayRegistry` che importa (riga 39). Senza `window` e' un
+// `ReferenceError` all'import, prima che qualsiasi componente sia costruito.
+//
+// react-native lo sa — il commento sopra quella riga dice "it is not mocked in
+// some Jest tests. We should update Jest tests setup". Il preset ufficiale se
+// la cava definendo `window`, che qui non e' un'opzione (vedi sopra).
+//
+// Il mock ufficiale `react-native/jest/mockModal.js` non aiuta: passa da
+// `mockComponent`, che fa `requireActual` di `Modal.js` e quindi riesegue lo
+// stesso import.
+//
+// La sostituzione e' quindi il ramo che react-native usa in produzione:
+// `AppContainer-prod`, che non legge nessun globale e non importa nulla — e'
+// il medesimo componente meno LogBox, l'inspector e gli overlay di debug,
+// cioe' esattamente cio' che nessun test vuole montare. Cosi' non serve
+// mockare separatamente la registry di debug: non viene mai caricata.
+jest.mock('react-native/Libraries/ReactNative/AppContainer', () => ({
+  __esModule: true,
+  default: jest.requireActual(
+    'react-native/Libraries/ReactNative/AppContainer-prod',
+  ).default,
+}));


### PR DESCRIPTION
Refs #101 — chiude la parte di ambiente. La parte residua è la #109 (aperta da questo lavoro).

## Il difetto

`render(<TournamentList/>)` moriva con `Invariant Violation: __fbBatchedBridgeConfig is not set`. Il danno era distribuito su **14 test sospesi** e **28 file `.tsx` esclusi**, e quindi invisibile come causa unica.

La causa non è `TurboModuleRegistry` — è solo dove la catena si vede morire. È il modulo sotto: `Libraries/BatchedBridge/NativeModules.js` solleva l'invariant **solo nel ramo `else`** di

```js
if (global.nativeModuleProxy) { NativeModules = global.nativeModuleProxy }
else { invariant(global.__fbBatchedBridgeConfig, '...') }
```

## Il fix

`jest.native-modules.js`, in `setupFiles` **prima** di `jest.env.js`, fornisce `global.nativeModuleProxy` — il punto d'innesto previsto dal runtime stesso. Costruisce un modulo nativo finto su richiesta, con i metodi come `jest.fn()`. Nessuna patch a react-native, nessun elenco di moduli da mantenere. Costanti vere per i due moduli dereferenziati subito (`DeviceInfo`, `PlatformConstants`).

Serve **un secondo mock, e uno solo**: `<Modal>` monta `AppContainer`, che con `__DEV__` vero sceglie il ramo `-dev`, che legge `window.__REACT_DEVTOOLS_GLOBAL_HOOK__` a livello di modulo. Si usa il ramo `-prod`: stesso componente meno LogBox, inspector e overlay di debug.

### Perché non il preset ufficiale

Tentato nella #94 e di nuovo qui. Appende il runner, perché collide con il `jest.mock('react-native')` di `jest.env.js` che fa `requireActual`. E **non sarebbe adottabile comunque**: alla riga 58 definisce `window: { value: global }`, cioè ciò che `jest.env.js` vieta con una misura a supporto (#94) — almeno cinque moduli di questo codebase deducono di girare su web dall'*assenza* di `window`.

La barriera asserisce che `window` resti indefinito, così un futuro innesto del preset cade lì per primo.

## Cosa torna verde, e cosa no

Dei 14 test sospesi dalla #94:

| File | Test | Esito |
|---|---|---|
| `components/__tests__/TournamentList.migration.test.ts` | 4 | ✅ **attivi e verdi** |
| `__tests__/integration/vis-to-database-sync.test.ts` | 10 | ancora sospesi — **causa diversa** |

I dieci non sono bloccati dal rendering, e la prova è che i quattro che passano montano **lo stesso `TournamentList`**. Precaricano un QueryClient con chiavi e snake_case di database che nessun hook interroga, montano i componenti veri senza mockarne gli hook — che emettono le proprie fetch, trovano `global.fetch` a 503 e ripartono col backoff — e asseriscono su stringhe già formattate che nessuno produce. È codice **mai eseguito in vita sua**: prima della #94 moriva all'import per il JSX in un file `.ts`. Riscriverlo è lavoro di natura diversa → **#109**.

## I `.tsx` restano esclusi, e la riga smette di mentire

Diceva *"React Native setup complexity"*. Misurato togliendo l'esclusione: **2 file verdi su 28**, ~148 rossi.

| Famiglia | Occorrenze |
|---|---|
| `Unable to find an element with text` | 166 |
| `Unable to find an element with role` | 64 |
| `toHaveStyle` | 56 |
| `toHaveBeenCalledTimes` | 36 |
| `Cannot find module` | 12 |
| `Unable to find an element with testID` | 4 |
| **`__fbBatchedBridgeConfig`** | **0** |
| **`ReferenceError: window`** | **0** |

Si montano tutti. Sbagliano sulle proprie asserzioni, invecchiate mentre nessuno le eseguiva. È manutenzione per file, non configurazione — i numeri sono nel commento in `jest.config.js`.

## Barriera

`__tests__/jest-native-modules.test.ts`, 18 test: monta i 13 componenti della catena nativa (`View`, `ScrollView`, `ActivityIndicator`, `TextInput`, `Image`, `Pressable`, `TouchableOpacity`, `FlatList`, `Switch`, `Modal`, `Animated.View`, `RefreshControl`), verifica le costanti al livello interno, la stabilità dei mock inventati, e che `window` non esista.

Esiste perché la causa aveva bisogno di **un posto dove essere visibile da sola**: se qualcuno tocca il setup, il primo rosso deve comparire lì con un nome che dice cosa è successo, non in una suite a caso fra 142.

## Acceptance criteria

- [x] `render(<TournamentList/>)` funziona senza Invariant Violation
- [x] I test sospesi tornano attivi e passano — **4 su 14**; i 10 di `vis-to-database-sync` sono #109, con la ragione misurata
- [x] Le suite già verdi restano verdi — nessuna regressione
- [x] Valutato se riabilitare i `.tsx` → **no**, con i numeri sopra, documentato in `jest.config.js`
- [x] Il run non peggiora — **~167 s** contro una baseline di ~170 s

```
Test Suites: 142 passed, 142 total
Tests:       18 skipped, 2167 passed, 2185 total
```

Erano 140 suite / 2145 test / 22 skipped. Numeri identici su due run consecutivi. Audit: PASS su tutti e 9 i checker.

Documentazione: nuova sezione in `TESTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtHCZUy32Vg41xVSc85CYy